### PR TITLE
Fix CallToolAsync for tools with no arguments

### DIFF
--- a/samples/microsoft.extensions.ai/tools/ToolsConsole/McpAIFunction.cs
+++ b/samples/microsoft.extensions.ai/tools/ToolsConsole/McpAIFunction.cs
@@ -43,7 +43,7 @@ public class McpAIFunction : AIFunction
         // Call the tool through mcpdotnet
         var result = await _client.CallToolAsync(
             _tool.Name,
-            argDict.Count == 0 ? null: argDict,
+            argDict.Count == 0 ? new(): argDict,
             cancellationToken: cancellationToken
         );
 

--- a/src/mcpdotnet/Client/McpClient.cs
+++ b/src/mcpdotnet/Client/McpClient.cs
@@ -346,7 +346,7 @@ internal class McpClient : IMcpClient
             new JsonRpcRequest
             {
                 Method = "tools/call",
-                Params = CreateParametersDictionary(toolName, arguments)
+                Params = CreateParametersDictionary(toolName, arguments ?? new())
             },
             cancellationToken
         ).ConfigureAwait(false);

--- a/src/mcpdotnet/mcpdotnet.csproj
+++ b/src/mcpdotnet/mcpdotnet.csproj
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <!-- license and package properties -->
     <PackageId>mcpdotnet</PackageId>
-    <Version>0.9.0.1</Version>
+    <Version>0.10.0.1</Version>
     <Authors>PederHP</Authors>
     <Description>.NET client library for the Model Context Protocol (MCP)</Description>
     <PackageProjectUrl>https://github.com/PederHP/mcpdotnet</PackageProjectUrl>


### PR DESCRIPTION
# Pull Request

## Description of Changes
Fixed CallToolAsync so that it no longer fails with some servers if a null argument dictionary is passed.

## Testing Done
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed

## Breaking Changes
None