### PR TITLE
Linux-related stdio fixes and update version

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -166,7 +166,6 @@ while (true)
 - Performance optimization
 - SSE server support
 - Authentication
-- Linux/Mac support for stdio transport
 
 ## License
 

--- a/src/mcpdotnet/Logging/Log.cs
+++ b/src/mcpdotnet/Logging/Log.cs
@@ -1,5 +1,4 @@
-﻿using McpDotNet.Configuration;
-using McpDotNet.Protocol.Messages;
+﻿using McpDotNet.Protocol.Messages;
 using Microsoft.Extensions.Logging;
 
 namespace McpDotNet.Logging;

--- a/src/mcpdotnet/Protocol/Transport/SseClientTransport.cs
+++ b/src/mcpdotnet/Protocol/Transport/SseClientTransport.cs
@@ -1,6 +1,4 @@
-﻿
-using System.Diagnostics.Tracing;
-using System.Text.Json;
+﻿using System.Text.Json;
 using System.Text;
 using McpDotNet.Protocol.Messages;
 using McpDotNet.Configuration;
@@ -9,7 +7,6 @@ using McpDotNet.Logging;
 using System.Net.Http.Headers;
 using System.Text.Json.Serialization;
 using McpDotNet.Utils.Json;
-using System.Threading;
 
 namespace McpDotNet.Protocol.Transport;
 

--- a/src/mcpdotnet/Protocol/Transport/StdioClientTransport.cs
+++ b/src/mcpdotnet/Protocol/Transport/StdioClientTransport.cs
@@ -61,7 +61,7 @@ public sealed class StdioClientTransport : TransportBase, IClientTransport
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
-                CreateNoWindow = true,
+                CreateNoWindow = OperatingSystem.IsWindows(),
                 WorkingDirectory = _options.WorkingDirectory ?? Environment.CurrentDirectory,
             };
 

--- a/src/mcpdotnet/mcpdotnet.csproj
+++ b/src/mcpdotnet/mcpdotnet.csproj
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <!-- license and package properties -->
     <PackageId>mcpdotnet</PackageId>
-    <Version>1.0.0.1</Version>
+    <Version>1.0.1.1</Version>
     <Authors>PederHP</Authors>
     <Description>.NET client library for the Model Context Protocol (MCP)</Description>
     <PackageProjectUrl>https://github.com/PederHP/mcpdotnet</PackageProjectUrl>


### PR DESCRIPTION
# Pull Request

## Description of Changes
<!-- Please provide a clear and concise description of your changes -->
- Modified `GetCommand` to return OS-specific commands and changed return type to `string?`.
- Improved `InitializeCommand` for better command initialization and logging.
- Cleaned up using directives in `Log.cs` and `SseClientTransport.cs`.
- Updated `CreateNoWindow` property in `StdioClientTransport` to be OS-dependent.
- Bumped version number in `mcpdotnet.csproj` to 1.0.1.1.

## Related Issue(s)
- Fixes Linux client issues related to hardcoded shell wrapping of MCP servers using stdio transport

## Testing Done
- [ ] Unit tests added/updated
- [X] Integration tests added/updated
- [X] Manual testing performed