### PR TITLE
Add netstandard2.0 support

### DIFF
--- a/src/Common/Polyfills/System/Collections/Generic/CollectionExtensions.cs
+++ b/src/Common/Polyfills/System/Collections/Generic/CollectionExtensions.cs
@@ -1,0 +1,19 @@
+namespace System.Collections.Generic;
+
+internal static class CollectionExtensions
+{
+    public static TValue? GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key)
+    {
+        return dictionary.GetValueOrDefault(key, default!);
+    }
+
+    public static TValue GetValueOrDefault<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue)
+    {
+        if (dictionary is null)
+        {
+            throw new ArgumentNullException(nameof(dictionary));
+        }
+
+        return dictionary.TryGetValue(key, out TValue? value) ? value : defaultValue;
+    }
+}

--- a/src/Common/Polyfills/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
+++ b/src/Common/Polyfills/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+    internal sealed class AllowNullAttribute : Attribute;
+
+    /// <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+    internal sealed class DisallowNullAttribute : Attribute;
+
+    /// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed class MaybeNullAttribute : Attribute;
+
+    /// <summary>Specifies that an output will not be null even if the corresponding type allows it. Specifies that an input argument was not null when the call returns.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed class NotNullAttribute : Attribute;
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class MaybeNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter may be null.
+        /// </param>
+        public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+    internal sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the associated parameter name.</summary>
+        /// <param name="parameterName">
+        /// The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+        /// </param>
+        public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
+
+        /// <summary>Gets the associated parameter name.</summary>
+        public string ParameterName { get; }
+    }
+
+    /// <summary>Applied to a method that will never return under any circumstance.</summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    internal sealed class DoesNotReturnAttribute : Attribute;
+
+    /// <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class DoesNotReturnIfAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified parameter value.</summary>
+        /// <param name="parameterValue">
+        /// The condition parameter value. Code after the method will be considered unreachable by diagnostics if the argument to
+        /// the associated parameter matches this value.
+        /// </param>
+        public DoesNotReturnIfAttribute(bool parameterValue) => ParameterValue = parameterValue;
+
+        /// <summary>Gets the condition parameter value.</summary>
+        public bool ParameterValue { get; }
+    }
+
+    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    internal sealed class MemberNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with a field or property member.</summary>
+        /// <param name="member">
+        /// The field or property member that is promised to be not-null.
+        /// </param>
+        public MemberNotNullAttribute(string member) => Members = [member];
+
+        /// <summary>Initializes the attribute with the list of field and property members.</summary>
+        /// <param name="members">
+        /// The list of field and property members that are promised to be not-null.
+        /// </param>
+        public MemberNotNullAttribute(params string[] members) => Members = members;
+
+        /// <summary>Gets field or property member names.</summary>
+        public string[] Members { get; }
+    }
+
+    /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    internal sealed class MemberNotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition and a field or property member.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated field or property member will not be null.
+        /// </param>
+        /// <param name="member">
+        /// The field or property member that is promised to be not-null.
+        /// </param>
+        public MemberNotNullWhenAttribute(bool returnValue, string member)
+        {
+            ReturnValue = returnValue;
+            Members = [member];
+        }
+
+        /// <summary>Initializes the attribute with the specified return value condition and list of field and property members.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated field and property members will not be null.
+        /// </param>
+        /// <param name="members">
+        /// The list of field and property members that are promised to be not-null.
+        /// </param>
+        public MemberNotNullWhenAttribute(bool returnValue, params string[] members)
+        {
+            ReturnValue = returnValue;
+            Members = members;
+        }
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+
+        /// <summary>Gets field or property member names.</summary>
+        public string[] Members { get; }
+    }
+}

--- a/src/Common/Polyfills/System/Diagnostics/CodeAnalysis/SetsRequiredMembersAttribute.cs
+++ b/src/Common/Polyfills/System/Diagnostics/CodeAnalysis/SetsRequiredMembersAttribute.cs
@@ -1,0 +1,5 @@
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
+    internal sealed class SetsRequiredMembersAttribute : Attribute;
+}

--- a/src/Common/Polyfills/System/Diagnostics/ProcessExtensions.cs
+++ b/src/Common/Polyfills/System/Diagnostics/ProcessExtensions.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics;
+
+internal static class ProcessExtensions
+{
+    public static void Kill(this Process process, bool entireProcessTree)
+    {
+        _ = entireProcessTree;
+        process.Kill();
+    }
+}

--- a/src/Common/Polyfills/System/IO/TextReaderExtensions.cs
+++ b/src/Common/Polyfills/System/IO/TextReaderExtensions.cs
@@ -1,0 +1,10 @@
+namespace System.IO;
+
+internal static class TextReaderExtensions
+{
+    public static Task<string> ReadLineAsync(this TextReader reader, CancellationToken cancellationToken)
+    {
+        _ = cancellationToken;
+        return reader.ReadLineAsync();
+    }
+}

--- a/src/Common/Polyfills/System/IO/TextWriterExtensions.cs
+++ b/src/Common/Polyfills/System/IO/TextWriterExtensions.cs
@@ -1,0 +1,42 @@
+using System.Runtime.InteropServices;
+
+namespace System.IO;
+
+internal static class TextWriterExtensions
+{
+    public static async Task WriteLineAsync(this TextWriter writer, ReadOnlyMemory<char> value, CancellationToken cancellationToken)
+    {
+        if (writer is null)
+        {
+            throw new ArgumentNullException(nameof(writer));
+        }
+
+        if (value.IsEmpty)
+        {
+            return;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (MemoryMarshal.TryGetString(value, out string str, out int start, out int length) &&
+            start == 0 && length == str.Length)
+        {
+            await writer.WriteLineAsync(str).ConfigureAwait(false);
+        }
+        else if (MemoryMarshal.TryGetArray(value, out ArraySegment<char> array) &&
+            array.Array is not null && array.Offset == 0 && array.Count == array.Array.Length)
+        {
+            await writer.WriteLineAsync(array.Array).ConfigureAwait(false);
+        }
+        else
+        {
+            await writer.WriteLineAsync(value.ToArray()).ConfigureAwait(false);
+        }
+    }
+
+    public static async Task FlushAsync(this TextWriter writer, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await writer.FlushAsync();
+    }
+}

--- a/src/Common/Polyfills/System/Net/Http/HttpClientExtensions.cs
+++ b/src/Common/Polyfills/System/Net/Http/HttpClientExtensions.cs
@@ -1,0 +1,26 @@
+namespace System.Net.Http;
+
+internal static class HttpClientExtensions
+{
+    public static async Task<Stream> ReadAsStreamAsync(this HttpContent content, CancellationToken cancellationToken)
+    {
+        if (content is null)
+        {
+            throw new ArgumentNullException(nameof(content));
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        return await content.ReadAsStreamAsync();
+    }
+
+    public static async Task<string> ReadAsStringAsync(this HttpContent content, CancellationToken cancellationToken)
+    {
+        if (content is null)
+        {
+            throw new ArgumentNullException(nameof(content));
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        return await content.ReadAsStringAsync();
+    }
+}

--- a/src/Common/Polyfills/System/Runtime/CompilerServices/CompilerFeatureRequiredAttribute.cs
+++ b/src/Common/Polyfills/System/Runtime/CompilerServices/CompilerFeatureRequiredAttribute.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Indicates that compiler support for a particular feature is required for the location where this attribute is applied.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
+    internal sealed class CompilerFeatureRequiredAttribute : Attribute
+    {
+        public CompilerFeatureRequiredAttribute(string featureName)
+        {
+            FeatureName = featureName;
+        }
+
+        /// <summary>
+        /// The name of the compiler feature.
+        /// </summary>
+        public string FeatureName { get; }
+
+        /// <summary>
+        /// If true, the compiler can choose to allow access to the location where this attribute is applied if it does not understand <see cref="FeatureName"/>.
+        /// </summary>
+        public bool IsOptional { get; init; }
+
+        /// <summary>
+        /// The <see cref="FeatureName"/> used for the required members C# feature.
+        /// </summary>
+        public const string RequiredMembers = nameof(RequiredMembers);
+    }
+}

--- a/src/Common/Polyfills/System/Runtime/CompilerServices/IsExternalInit.cs
+++ b/src/Common/Polyfills/System/Runtime/CompilerServices/IsExternalInit.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit;
+}

--- a/src/Common/Polyfills/System/Runtime/CompilerServices/RequiredMemberAttribute.cs
+++ b/src/Common/Polyfills/System/Runtime/CompilerServices/RequiredMemberAttribute.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>Specifies that a type has required members or that a member is required.</summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal sealed class RequiredMemberAttribute : Attribute;
+}

--- a/src/Common/Polyfills/System/Threading/CancellationTokenSourceExtensions.cs
+++ b/src/Common/Polyfills/System/Threading/CancellationTokenSourceExtensions.cs
@@ -1,0 +1,17 @@
+using System.Text;
+
+namespace System.Threading.Tasks;
+
+internal static class CancellationTokenSourceExtensions
+{
+    public static Task CancelAsync(this CancellationTokenSource cancellationTokenSource)
+    {
+        if (cancellationTokenSource is null)
+        {
+            throw new ArgumentNullException(nameof(cancellationTokenSource));
+        }
+
+        cancellationTokenSource.Cancel();
+        return Task.CompletedTask;
+    }
+}

--- a/src/Common/Polyfills/System/Threading/Tasks/TaskExtensions.cs
+++ b/src/Common/Polyfills/System/Threading/Tasks/TaskExtensions.cs
@@ -1,0 +1,48 @@
+namespace System.Threading.Tasks;
+
+internal static class TaskExtensions
+{
+    public static Task WaitAsync(this Task task, CancellationToken cancellationToken)
+    {
+        return WaitAsync(task, Timeout.InfiniteTimeSpan, cancellationToken);
+    }
+
+    public static async Task<T> WaitAsync<T>(this Task<T> task, CancellationToken cancellationToken)
+    {
+        await WaitAsync(task, Timeout.InfiniteTimeSpan, cancellationToken);
+        return task.Result;
+    }
+
+    public static async Task WaitAsync(this Task task, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        if (task is null)
+        {
+            throw new ArgumentNullException(nameof(task));
+        }
+
+        if (timeout < TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeout));
+        }
+
+        if (!task.IsCompleted)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(timeout);
+
+            var cancellationTask = new TaskCompletionSource<bool>();
+            using var _ = cts.Token.Register(tcs => ((TaskCompletionSource<bool>)tcs!).TrySetResult(true), cancellationTask);
+            await Task.WhenAny(task, cancellationTask.Task).ConfigureAwait(false);
+            
+            if (!task.IsCompleted)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                throw new TimeoutException();
+            }
+        }
+
+        await task.ConfigureAwait(false);
+    }
+}

--- a/src/McpDotNet.Extensions.AI/McpDotNet.Extensions.AI.csproj
+++ b/src/McpDotNet.Extensions.AI/McpDotNet.Extensions.AI.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\McpDotNet\McpDotNet.csproj" />
+    <ProjectReference Include="..\mcpdotnet\mcpdotnet.csproj" />
 
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.3.0-preview.1.25114.11" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="9.3.0-preview.1.25114.11" />

--- a/src/McpDotNet.Extensions.AI/McpDotNet.Extensions.AI.csproj
+++ b/src/McpDotNet.Extensions.AI/McpDotNet.Extensions.AI.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -35,9 +36,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\McpDotNet\McpDotNet.csproj" />
+
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.3.0-preview.1.25114.11" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="9.3.0-preview.1.25114.11" />
-    <PackageReference Include="mcpdotnet" Version="1.0.1.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Text.Json" Version="9.0.2" />
   </ItemGroup>
 
 </Project>

--- a/src/McpDotNet.Extensions.AI/McpSessionScope.cs
+++ b/src/McpDotNet.Extensions.AI/McpSessionScope.cs
@@ -45,7 +45,7 @@ public class McpSessionScope : IAsyncDisposable
         scope.Tools = tools.Tools.Select(t => new McpAIFunction(t, client)).ToList<AITool>();
         if (!string.IsNullOrEmpty(client.ServerInstructions))
         {
-            scope.ServerInstructions = [client.ServerInstructions];
+            scope.ServerInstructions = [client.ServerInstructions!];
         }
         return scope;
     }

--- a/src/mcpdotnet/Client/McpClientFactory.cs
+++ b/src/mcpdotnet/Client/McpClientFactory.cs
@@ -2,6 +2,7 @@
 using McpDotNet.Logging;
 using McpDotNet.Protocol.Transport;
 using Microsoft.Extensions.Logging;
+using System.Runtime.InteropServices;
 
 namespace McpDotNet.Client;
 /// <summary>
@@ -139,7 +140,7 @@ public class McpClientFactory
         if (string.IsNullOrEmpty(command))
             return config.Location!;
 
-        return OperatingSystem.IsWindows() ? "cmd.exe" : command;
+        return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "cmd.exe" : command!;
     }
 
     /// <summary>
@@ -152,13 +153,13 @@ public class McpClientFactory
         // If the command is empty or already contains cmd.exe, we don't need to do anything
         var command = config.TransportOptions?.GetValueOrDefault("command");
 
-        if (string.IsNullOrEmpty(command) || !OperatingSystem.IsWindows())
+        if (string.IsNullOrEmpty(command) || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             return;
         }
 
         // On Windows, we need to wrap non-shell commands with cmd.exe /c
-        if (command.Contains("cmd.exe", StringComparison.OrdinalIgnoreCase))
+        if (command!.IndexOf("cmd.exe", StringComparison.OrdinalIgnoreCase) >= 0)
         {
             _logger.SkippingShellWrapper(endpointName);
             return;

--- a/src/mcpdotnet/Protocol/Transport/PasteArguments.cs
+++ b/src/mcpdotnet/Protocol/Transport/PasteArguments.cs
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Copied from:
+// https://github.com/dotnet/runtime/blob/d2650b6ae7023a2d9d2c74c56116f1f18472ab04/src/libraries/System.Private.CoreLib/src/System/PasteArguments.cs
+// and changed from using ValueStringBuilder to StringBuilder.
+
+using System.Text;
+
+namespace McpDotNet.Protocol.Transport
+{
+    internal static partial class PasteArguments
+    {
+        internal static void AppendArgument(StringBuilder stringBuilder, string argument)
+        {
+            if (stringBuilder.Length != 0)
+            {
+                stringBuilder.Append(' ');
+            }
+
+            // Parsing rules for non-argv[0] arguments:
+            //   - Backslash is a normal character except followed by a quote.
+            //   - 2N backslashes followed by a quote ==> N literal backslashes followed by unescaped quote
+            //   - 2N+1 backslashes followed by a quote ==> N literal backslashes followed by a literal quote
+            //   - Parsing stops at first whitespace outside of quoted region.
+            //   - (post 2008 rule): A closing quote followed by another quote ==> literal quote, and parsing remains in quoting mode.
+            if (argument.Length != 0 && ContainsNoWhitespaceOrQuotes(argument))
+            {
+                // Simple case - no quoting or changes needed.
+                stringBuilder.Append(argument);
+            }
+            else
+            {
+                stringBuilder.Append(Quote);
+                int idx = 0;
+                while (idx < argument.Length)
+                {
+                    char c = argument[idx++];
+                    if (c == Backslash)
+                    {
+                        int numBackSlash = 1;
+                        while (idx < argument.Length && argument[idx] == Backslash)
+                        {
+                            idx++;
+                            numBackSlash++;
+                        }
+
+                        if (idx == argument.Length)
+                        {
+                            // We'll emit an end quote after this so must double the number of backslashes.
+                            stringBuilder.Append(Backslash, numBackSlash * 2);
+                        }
+                        else if (argument[idx] == Quote)
+                        {
+                            // Backslashes will be followed by a quote. Must double the number of backslashes.
+                            stringBuilder.Append(Backslash, numBackSlash * 2 + 1);
+                            stringBuilder.Append(Quote);
+                            idx++;
+                        }
+                        else
+                        {
+                            // Backslash will not be followed by a quote, so emit as normal characters.
+                            stringBuilder.Append(Backslash, numBackSlash);
+                        }
+
+                        continue;
+                    }
+
+                    if (c == Quote)
+                    {
+                        // Escape the quote so it appears as a literal. This also guarantees that we won't end up generating a closing quote followed
+                        // by another quote (which parses differently pre-2008 vs. post-2008.)
+                        stringBuilder.Append(Backslash);
+                        stringBuilder.Append(Quote);
+                        continue;
+                    }
+
+                    stringBuilder.Append(c);
+                }
+
+                stringBuilder.Append(Quote);
+            }
+        }
+
+        private static bool ContainsNoWhitespaceOrQuotes(string s)
+        {
+            for (int i = 0; i < s.Length; i++)
+            {
+                char c = s[i];
+                if (char.IsWhiteSpace(c) || c == Quote)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private const char Quote = '\"';
+        private const char Backslash = '\\';
+    }
+}

--- a/src/mcpdotnet/Protocol/Transport/SseClientTransport.cs
+++ b/src/mcpdotnet/Protocol/Transport/SseClientTransport.cs
@@ -63,13 +63,7 @@ public sealed class SseClientTransport : TransportBase, IClientTransport
 
             _logger.TransportReadingMessages(EndpointName);
 
-            await Task.WhenAny(
-                _connectionEstablished.Task,
-                Task.Delay(_options.ConnectionTimeout, cancellationToken)
-            );
-
-            if (!IsConnected)
-                throw new TimeoutException("Failed to receive endpoint event");
+            await _connectionEstablished.Task.WaitAsync(_options.ConnectionTimeout, cancellationToken);
         }
         catch (McpTransportException)
         {

--- a/src/mcpdotnet/Protocol/Transport/StdioServerTransport.cs
+++ b/src/mcpdotnet/Protocol/Transport/StdioServerTransport.cs
@@ -48,7 +48,7 @@ public sealed class StdioServerTransport : TransportBase, IServerTransport
     {
         _shutdownCts = new CancellationTokenSource();
 
-        _readTask = Task.Run(async () => await ReadMessagesAsync(_shutdownCts.Token));
+        _readTask = Task.Run(async () => await ReadMessagesAsync(_shutdownCts.Token), CancellationToken.None);
 
         SetConnected(true);
 
@@ -79,7 +79,7 @@ public sealed class StdioServerTransport : TransportBase, IServerTransport
             using (Console.OpenStandardOutput())
             {
                 await Console.Out.WriteLineAsync(json.AsMemory(), cancellationToken);
-                await Console.Out.FlushAsync();
+                await Console.Out.FlushAsync(cancellationToken);
             }
 
             _logger.TransportSentMessage(EndpointName, id);

--- a/src/mcpdotnet/Shared/McpJsonRpcEndpoint.cs
+++ b/src/mcpdotnet/Shared/McpJsonRpcEndpoint.cs
@@ -71,7 +71,7 @@ internal abstract class McpJsonRpcEndpoint
                 // Fire and forget the message handling task to avoid blocking the transport
                 // If awaiting the task, the transport will not be able to read more messages,
                 // which could lead to a deadlock if the handler sends a message back
-                FireAndForget(Task.Run(() => HandleMessageAsync(message, cancellationToken)), message);
+                FireAndForget(Task.Run(() => HandleMessageAsync(message, cancellationToken), CancellationToken.None), message);
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -351,7 +351,10 @@ internal abstract class McpJsonRpcEndpoint
     /// <param name="handler">Handler to be called when a request with specified method identifier is received</param>
     protected void SetRequestHandler<TRequest, TResponse>(string method, Func<TRequest?, Task<TResponse>> handler) where TResponse : class
     {
-        ArgumentNullException.ThrowIfNull(handler);
+        if (handler is null)
+        {
+            throw new ArgumentNullException(nameof(handler));
+        }
 
         _requestHandlers[method] = async (request) =>
         {
@@ -397,9 +400,9 @@ internal abstract class McpJsonRpcEndpoint
         }
 
         // Complete all pending requests with cancellation
-        foreach (var (_, tcs) in _pendingRequests)
+        foreach (var entry in _pendingRequests)
         {
-            tcs.TrySetCanceled();
+            entry.Value.TrySetCanceled();
         }
         _pendingRequests.Clear();
 

--- a/src/mcpdotnet/mcpdotnet.csproj
+++ b/src/mcpdotnet/mcpdotnet.csproj
@@ -38,12 +38,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
+    <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.2" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <Compile Include="..\Common\Polyfills\**\*.cs" />
     <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.2" />
-    <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.2" />
     <PackageReference Include="System.Text.Json" Version="9.0.2" />
     <PackageReference Include="System.Threading.Channels" Version="9.0.2" />
   </ItemGroup>

--- a/src/mcpdotnet/mcpdotnet.csproj
+++ b/src/mcpdotnet/mcpdotnet.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>    
+    <Nullable>enable</Nullable>
+    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -35,8 +36,15 @@
   </ItemGroup>  
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <Compile Include="..\Common\Polyfills\**\*.cs" />
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.2" />
+    <PackageReference Include="System.Text.Json" Version="9.0.2" />
+    <PackageReference Include="System.Threading.Channels" Version="9.0.2" />
   </ItemGroup>
 
 </Project>

--- a/tests/McpDotNet.Extensions.AI.Tests/McpDotNet.Extensions.AI.Tests.csproj
+++ b/tests/McpDotNet.Extensions.AI.Tests/McpDotNet.Extensions.AI.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net472</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>Latest</LangVersion>

--- a/tests/McpDotNet.Extensions.AI.Tests/McpDotNet.Extensions.AI.Tests.csproj
+++ b/tests/McpDotNet.Extensions.AI.Tests/McpDotNet.Extensions.AI.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>Latest</LangVersion>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/tests/mcpdotnet.Tests/mcpdotnet.Tests.csproj
+++ b/tests/mcpdotnet.Tests/mcpdotnet.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>Latest</LangVersion>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>


### PR DESCRIPTION
# Pull Request

## Description of Changes

Enable mcpdotnet to be used with .NET Framework via a netstandard2.0 target.

## Testing Done

Updated the McpDotNet.Extensions.AI.Tests to run for net472 as well, but mcpdotnet.Tests has a dependency which requires net8.0.

## Breaking Changes
<!-- List any breaking changes here, or delete this section if none -->
None