### PR TITLE
Avoid new JsonSerializerOptions instances

### DIFF
--- a/src/mcpdotnet/Logging/Log.cs
+++ b/src/mcpdotnet/Logging/Log.cs
@@ -266,33 +266,6 @@ internal static partial class Log
     [LoggerMessage(Level = LogLevel.Information, Message = "Transport cleaned up for {endpointName}")]
     internal static partial void TransportCleanedUp(this ILogger logger, string endpointName);
 
-    [LoggerMessage(Level = LogLevel.Error, Message = "JSON-RPC message start object token expected")]
-    internal static partial void JsonRpcMessageConverterExpectedStartObjectToken(this ILogger logger);
-
-    [LoggerMessage(Level = LogLevel.Error, Message = "JSON-RPC message invalid version")]
-    internal static partial void JsonRpcMessageConverterInvalidJsonRpcVersion(this ILogger logger);
-
-    [LoggerMessage(Level = LogLevel.Trace, Message = "JSON-RPC message deserializing error response: {rawText}")]
-    internal static partial void JsonRpcMessageConverterDeserializingErrorResponse(this ILogger logger, string rawText);
-
-    [LoggerMessage(Level = LogLevel.Trace, Message = "JSON-RPC message deserializing response: {rawText}")]
-    internal static partial void JsonRpcMessageConverterDeserializingResponse(this ILogger logger, string rawText);
-
-    [LoggerMessage(Level = LogLevel.Error, Message = "JSON-RPC message response must have result or error: {rawText}")]
-    internal static partial void JsonRpcMessageConverterResponseMustHaveResultOrError(this ILogger logger, string rawText);
-
-    [LoggerMessage(Level = LogLevel.Trace, Message = "JSON-RPC message deserializing notification: {rawText}")]
-    internal static partial void JsonRpcMessageConverterDeserializingNotification(this ILogger logger, string rawText);
-
-    [LoggerMessage(Level = LogLevel.Trace, Message = "JSON-RPC message deserializing request: {rawText}")]
-    internal static partial void JsonRpcMessageConverterDeserializingRequest(this ILogger logger, string rawText);
-
-    [LoggerMessage(Level = LogLevel.Error, Message = "JSON-RPC message invalid format: {rawText}")]
-    internal static partial void JsonRpcMessageConverterInvalidMessageFormat(this ILogger logger, string rawText);
-
-    [LoggerMessage(Level = LogLevel.Error, Message = "JSON-RPC message write unknown message type: {type}")]
-    internal static partial void JsonRpcMessageConverterWriteUnknownMessageType(this ILogger logger, string type);
-
     [LoggerMessage(Level = LogLevel.Debug, Message = "Sending notification payload for {endpointName}: {payload}")]
     internal static partial void SendingNotificationPayload(this ILogger logger, string endpointName, string payload);
 

--- a/src/mcpdotnet/Protocol/Transport/SseClientTransport.cs
+++ b/src/mcpdotnet/Protocol/Transport/SseClientTransport.cs
@@ -43,7 +43,7 @@ public sealed class SseClientTransport : TransportBase, IClientTransport
         _httpClient = new HttpClient();
         _connectionCts = new CancellationTokenSource();
         _logger = loggerFactory.CreateLogger<SseClientTransport>();
-        _jsonOptions = new JsonSerializerOptions().ConfigureForMcp(loggerFactory);
+        _jsonOptions = JsonSerializerOptionsExtensions.DefaultOptions;
         _connectionEstablished = new TaskCompletionSource<bool>();
     }
 

--- a/src/mcpdotnet/Protocol/Transport/StdioClientTransport.cs
+++ b/src/mcpdotnet/Protocol/Transport/StdioClientTransport.cs
@@ -36,7 +36,7 @@ public sealed class StdioClientTransport : TransportBase, IClientTransport
         _options = options;
         _serverConfig = serverConfig;
         _logger = loggerFactory.CreateLogger<StdioClientTransport>();
-        _jsonOptions = new JsonSerializerOptions().ConfigureForMcp(loggerFactory);
+        _jsonOptions = JsonSerializerOptionsExtensions.DefaultOptions;
     }
 
     /// <inheritdoc/>

--- a/src/mcpdotnet/Protocol/Transport/StdioServerTransport.cs
+++ b/src/mcpdotnet/Protocol/Transport/StdioServerTransport.cs
@@ -40,7 +40,7 @@ public sealed class StdioServerTransport : TransportBase, IServerTransport
     {
         _serverName = serverName;
         _logger = loggerFactory.CreateLogger<StdioClientTransport>();
-        _jsonOptions = new JsonSerializerOptions().ConfigureForMcp(loggerFactory);
+        _jsonOptions = JsonSerializerOptionsExtensions.DefaultOptions;
     }
 
     /// <inheritdoc/>

--- a/src/mcpdotnet/Shared/McpJsonRpcEndpoint.cs
+++ b/src/mcpdotnet/Shared/McpJsonRpcEndpoint.cs
@@ -37,7 +37,7 @@ internal abstract class McpJsonRpcEndpoint
         _pendingRequests = new();
         _notificationHandlers = new();
         _nextRequestId = 1;
-        _jsonOptions = new JsonSerializerOptions().ConfigureForMcp(loggerFactory);
+        _jsonOptions = JsonSerializerOptionsExtensions.DefaultOptions;
         _logger = loggerFactory.CreateLogger<McpClient>();
     }
 

--- a/src/mcpdotnet/Utils/Json/JsonSerializerOptionsExtensions.cs
+++ b/src/mcpdotnet/Utils/Json/JsonSerializerOptionsExtensions.cs
@@ -3,21 +3,24 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace McpDotNet.Utils.Json;
+
 /// <summary>
 /// Extensions for configuring System.Text.Json serialization options for MCP.
 /// </summary>
 internal static class JsonSerializerOptionsExtensions
 {
+    public static JsonSerializerOptions DefaultOptions { get; } = CreateDefaultOptions();
+
     /// <summary>
-    /// Configures JsonSerializerOptions with MCP-specific settings and converters.
+    /// Creates default options to use for MCP-related serialization.
     /// </summary>
-    /// <param name="options">The options to configure.</param>
-    /// <param name="loggerFactory">The logger factory to use for logging.</param>
     /// <returns>The configured options.</returns>
-    public static JsonSerializerOptions ConfigureForMcp(this JsonSerializerOptions options, ILoggerFactory loggerFactory)
+    private static JsonSerializerOptions CreateDefaultOptions()
     {
+        JsonSerializerOptions options = new();
+
         // Add custom converters
-        options.Converters.Add(new JsonRpcMessageConverter(loggerFactory.CreateLogger<JsonRpcMessageConverter>()));
+        options.Converters.Add(new JsonRpcMessageConverter());
         options.Converters.Add(new JsonStringEnumConverter());
 
         // Configure general options


### PR DESCRIPTION
# Pull Request

## Description of Changes

We try hard to avoid creating unnecessary JsonSerializerOptions, as each can have a non-trivial overhead due to how reflection is used by JsonSerializer and the JSO instance serving as a cache.  Rather than creating a new JSO for each transport / endpoint, this can just use a singleton. The only thing it loses is logging when the converter fails, but all of those paths are also throwing an exception, which can be logged higher in the call stack.

## Breaking Changes
<!-- List any breaking changes here, or delete this section if none -->
None