### PR TITLE
Fix McpAIFunction to override Name/Description

### DIFF
--- a/src/McpDotNet.Extensions.AI/McpAIFunction.cs
+++ b/src/McpDotNet.Extensions.AI/McpAIFunction.cs
@@ -23,7 +23,10 @@ public class McpAIFunction : AIFunction
     }
 
     /// <inheritdoc/>
-    public override string ToString() => _tool.Name;
+    public override string Name => _tool.Name;
+
+    /// <inheritdoc/>
+    public override string Description => _tool.Description ?? string.Empty;
 
     /// <inheritdoc/>
     public override JsonElement JsonSchema => AIFunctionUtilities.MapToJsonElement(_tool);
@@ -42,14 +45,9 @@ public class McpAIFunction : AIFunction
         }
 
         // Call the tool through mcpdotnet
-        var result = await _client.CallToolAsync(
-            _tool.Name,
-            argDict.Count == 0 ? [] : argDict,
-            cancellationToken: cancellationToken
-        );
+        var result = await _client.CallToolAsync(_tool.Name, argDict, cancellationToken);
 
-        // Extract the text content from the result
-        // For simplicity in this sample, we'll just concatenate all text content
+        // Extract the text content from the result.
         return string.Join("\n", result.Content
             .Where(c => c.Type == "text")
             .Select(c => c.Text));


### PR DESCRIPTION
# Pull Request

## Description of Changes

McpAIFunction should override AIFunction.Name/Description. Without that, Description would end up being empty and Name would end up being "McpAIFunction"; these values are used by IChatClient implementations when sending tool information.

It also doesn't need to override ToString, as the base just returns Name from that, and it doesn't need to construct a new empty dictionary when it already has an empty one.

## Breaking Changes
<!-- List any breaking changes here, or delete this section if none -->
None