### PR TITLE
xmldoc about stdout logging conflicts with stdiotransport

### DIFF
--- a/src/mcpdotnet/Configuration/McpServerBuilderExtensions.Transports.cs
+++ b/src/mcpdotnet/Configuration/McpServerBuilderExtensions.Transports.cs
@@ -11,6 +11,8 @@ public static partial class McpServerBuilderExtensions
 {
     /// <summary>
     /// Adds a server transport that uses stdin/stdout for communication.
+    /// 
+    /// NB! Make sure to not register a logger factory that logs to stdout, as it will interfere with the communication.
     /// </summary>
     /// <param name="builder">The builder instance.</param>
     public static IMcpServerBuilder WithStdioServerTransport(this IMcpServerBuilder builder)


### PR DESCRIPTION
When using the builder extensions, it is easy to accidentally inject an ILoggerFactory which uses a stdout based provider. It might even be the default.

I've added a warning to WithStdioServerTransport, but ideally we'd also want to detect it (at least for non-third party loggers) in CreateServer and throw an exception, but I am not sure what ILoggerFactory to check for - or if it's even possible to identify. 