### PR TITLE
Update StdioClientTransport.cs

### DIFF
--- a/src/mcpdotnet/Protocol/Transport/StdioClientTransport.cs
+++ b/src/mcpdotnet/Protocol/Transport/StdioClientTransport.cs
@@ -209,7 +209,8 @@ public sealed class StdioClientTransport : TransportBase, IClientTransport
     private async Task ProcessMessageAsync(string line, CancellationToken cancellationToken)
     {
         try
-        {
+        {                    
+            line=line.Trim();//Fixes an error when the service prefixes nonprintable characters
             var message = JsonSerializer.Deserialize<IJsonRpcMessage>(line, _jsonOptions);
             if (message != null)
             {


### PR DESCRIPTION
# Pull Request

## Description of Changes
@modelcontextprotocol/server-github returns a `\f` character before sending json. This causes the deserializer to fail.

## Related Issue(s)
I didn't create an issue.

## Testing Done
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Breaking Changes
Shouldn't cause any issues, trimming takes place just before a json parse.