### PR TITLE
Add AspNetCoreSseServer sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Cake tools
-[Tt]ools/
+/[Tt]ools/
 
 # Build output
 [Bb]uildArtifacts/

--- a/mcpdotnet.sln
+++ b/mcpdotnet.sln
@@ -23,6 +23,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{2A77AF5C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mcpdotnet.TestSseServer", "tests\mcpdotnet.TestSseServer\mcpdotnet.TestSseServer.csproj", "{79B94BF9-E557-33DB-3F19-B2C7D9BF8C56}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetCoreSseServer", "samples\AspNetCoreSseServer\AspNetCoreSseServer.csproj", "{B6F42305-423F-56FF-090F-B7263547F924}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -61,6 +63,10 @@ Global
 		{79B94BF9-E557-33DB-3F19-B2C7D9BF8C56}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{79B94BF9-E557-33DB-3F19-B2C7D9BF8C56}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{79B94BF9-E557-33DB-3F19-B2C7D9BF8C56}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B6F42305-423F-56FF-090F-B7263547F924}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B6F42305-423F-56FF-090F-B7263547F924}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B6F42305-423F-56FF-090F-B7263547F924}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B6F42305-423F-56FF-090F-B7263547F924}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -71,6 +77,7 @@ Global
 		{CA0BB450-1903-2F92-A68D-1285976551D6} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{7C229573-A085-4ECC-8131-958CDA2BE731} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{6499876E-2F76-44A8-B6EB-5B889C6E9B7F} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{B6F42305-423F-56FF-090F-B7263547F924} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {384A3888-751F-4D75-9AE5-587330582D89}

--- a/samples/AspNetCoreSseServer/AspNetCoreSseMcpTransport.cs
+++ b/samples/AspNetCoreSseServer/AspNetCoreSseMcpTransport.cs
@@ -1,0 +1,86 @@
+﻿using System.Buffers;
+using System.Net.ServerSentEvents;
+using System.Text.Json;
+using System.Threading.Channels;
+using McpDotNet.Protocol.Messages;
+using McpDotNet.Protocol.Transport;
+using McpDotNet.Utils.Json;
+
+namespace AspNetCoreSseServer;
+
+public class AspNetCoreSseMcpTransport(Stream sseResponseStream, ILogger<AspNetCoreSseMcpTransport> logger) : ITransport
+{
+    [ThreadStatic]
+    private static Utf8JsonWriter? _jsonWriter;
+
+    private readonly Channel<IJsonRpcMessage> _incomingChannel = CreateSingleItemChannel<IJsonRpcMessage>();
+    private readonly Channel<SseItem<IJsonRpcMessage?>> _outgoingSseChannel = CreateSingleItemChannel<SseItem<IJsonRpcMessage?>>();
+
+    private Task? _sseWriteTask;
+
+    public bool IsConnected => _sseWriteTask?.IsCompleted == false;
+
+    public Task RunAsync(CancellationToken cancellationToken)
+    {
+        static void WriteJsonRpcMessageToBuffer(SseItem<IJsonRpcMessage?> item, IBufferWriter<byte> writer)
+        {
+            if (item.EventType == "endpoint")
+            {
+                writer.Write("/message"u8);
+                return;
+            }
+
+            JsonSerializer.Serialize(GetUtf8JsonWriter(writer), item.Data, JsonSerializerOptionsExtensions.DefaultOptions);
+        }
+
+        // The very first SSE event isn't really an IJsonRpcMessage, but there's no API to write a single item of a different type,
+        // so we fib and special-case the "endpoint" event type in the formatter.
+        _outgoingSseChannel.Writer.TryWrite(new SseItem<IJsonRpcMessage?>(null, "endpoint"));
+
+        var sseItems = _outgoingSseChannel.Reader.ReadAllAsync(cancellationToken);
+        return _sseWriteTask = SseFormatter.WriteAsync(sseItems, sseResponseStream, WriteJsonRpcMessageToBuffer, cancellationToken);
+    }
+
+    public ChannelReader<IJsonRpcMessage> MessageReader => _incomingChannel.Reader;
+
+    public ValueTask DisposeAsync()
+    {
+        _incomingChannel.Writer.TryComplete();
+        _outgoingSseChannel.Writer.TryComplete();
+        return new ValueTask(_sseWriteTask ?? Task.CompletedTask);
+    }
+
+    public Task SendMessageAsync(IJsonRpcMessage message, CancellationToken cancellationToken = default) =>
+        _outgoingSseChannel.Writer.WriteAsync(new SseItem<IJsonRpcMessage?>(message), cancellationToken).AsTask();
+
+    public Task OnMessageReceivedAsync(IJsonRpcMessage message, CancellationToken cancellationToken)
+    {
+        if (!IsConnected)
+        {
+            throw new McpTransportException("Transport is not connected");
+        }
+
+        return _incomingChannel.Writer.WriteAsync(message, cancellationToken).AsTask();
+    }
+
+    private static Channel<T> CreateSingleItemChannel<T>() =>
+        Channel.CreateBounded<T>(new BoundedChannelOptions(1)
+        {
+            SingleReader = true,
+            SingleWriter = false,
+        });
+
+    private static Utf8JsonWriter GetUtf8JsonWriter(IBufferWriter<byte> writer)
+    {
+        if (_jsonWriter is null)
+        {
+            _jsonWriter = new Utf8JsonWriter(writer);
+        }
+        else
+        {
+            _jsonWriter.Reset(writer);
+        }
+
+        return _jsonWriter;
+    }
+}

--- a/samples/AspNetCoreSseServer/AspNetCoreSseServer.csproj
+++ b/samples/AspNetCoreSseServer/AspNetCoreSseServer.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\mcpdotnet\mcpdotnet.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Net.ServerSentEvents" Version="10.0.0-preview.1.25080.5" />
+  </ItemGroup>
+
+</Project>

--- a/samples/AspNetCoreSseServer/McpEndpointRouteBuilderExtensions.cs
+++ b/samples/AspNetCoreSseServer/McpEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,61 @@
+﻿using McpDotNet.Protocol.Messages;
+using McpDotNet.Server;
+using McpDotNet.Utils.Json;
+
+namespace AspNetCoreSseServer;
+
+public static class McpEndpointRouteBuilderExtensions
+{
+    public static IEndpointConventionBuilder MapMcpSse(this IEndpointRouteBuilder endpoints)
+    {
+        IMcpServer? server = null;
+        AspNetCoreSseMcpTransport? transport = null;
+        var mcpServerFactory = endpoints.ServiceProvider.GetRequiredService<IMcpServerFactory>();
+        var sseTransportLogger = endpoints.ServiceProvider.GetRequiredService<ILogger<AspNetCoreSseMcpTransport>>();
+
+        var routeGroup = endpoints.MapGroup("");
+
+        routeGroup.MapGet("/sse", async (HttpResponse response, CancellationToken requestAborted) =>
+        {
+            await using var localTransport = transport = new AspNetCoreSseMcpTransport(response.Body, sseTransportLogger);
+            await using var localServer = server = mcpServerFactory.CreateServer(transport);
+
+            await localServer.StartAsync(requestAborted);
+
+            response.Headers.ContentType = "text/event-stream";
+            response.Headers.CacheControl = "no-cache";
+
+            try
+            {
+                await transport.RunAsync(requestAborted);
+            }
+            catch (OperationCanceledException) when (requestAborted.IsCancellationRequested)
+            {
+                // RequestAborted always triggers when the client disconnects before a complete response body is written,
+                // but this is how SSE connections are typically closed.
+            }
+        });
+
+        routeGroup.MapPost("/message", async (HttpContext context) =>
+        {
+            if (transport is null)
+            {
+                await Results.BadRequest("Connect to the /sse endpoint before sending messages.").ExecuteAsync(context);
+                return;
+            }
+
+            var message = await context.Request.ReadFromJsonAsync<IJsonRpcMessage>(JsonSerializerOptionsExtensions.DefaultOptions, context.RequestAborted);
+            if (message is null)
+            {
+                await Results.BadRequest("No message in request body.").ExecuteAsync(context);
+                return;
+            }
+
+            await transport.OnMessageReceivedAsync(message, context.RequestAborted);
+            context.Response.StatusCode = StatusCodes.Status202Accepted;
+            await context.Response.WriteAsync("Accepted");
+        });
+
+        return routeGroup;
+    }
+}

--- a/samples/AspNetCoreSseServer/Program.cs
+++ b/samples/AspNetCoreSseServer/Program.cs
@@ -2,13 +2,7 @@ using McpDotNet;
 using AspNetCoreSseServer;
 
 var builder = WebApplication.CreateBuilder(args);
-builder.Services.AddMcpServer(options =>
-{
-    options.Capabilities = new()
-    {
-        Tools = new()
-    };
-}).WithTools();
+builder.Services.AddMcpServer().WithTools();
 var app = builder.Build();
 
 app.MapGet("/", () => "Hello World!");

--- a/samples/AspNetCoreSseServer/Program.cs
+++ b/samples/AspNetCoreSseServer/Program.cs
@@ -1,0 +1,17 @@
+using McpDotNet;
+using AspNetCoreSseServer;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddMcpServer(options =>
+{
+    options.Capabilities = new()
+    {
+        Tools = new()
+    };
+}).WithTools();
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello World!");
+app.MapMcpSse();
+
+app.Run();

--- a/samples/AspNetCoreSseServer/Properties/launchSettings.json
+++ b/samples/AspNetCoreSseServer/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:3001",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7133;http://localhost:3001",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/AspNetCoreSseServer/SseServerStreamTransport.cs
+++ b/samples/AspNetCoreSseServer/SseServerStreamTransport.cs
@@ -10,19 +10,17 @@ namespace AspNetCoreSseServer;
 
 public class SseServerStreamTransport(Stream sseResponseStream) : ITransport
 {
-    [ThreadStatic]
-    private static Utf8JsonWriter? _jsonWriter;
-
     private readonly Channel<IJsonRpcMessage> _incomingChannel = CreateSingleItemChannel<IJsonRpcMessage>();
     private readonly Channel<SseItem<IJsonRpcMessage?>> _outgoingSseChannel = CreateSingleItemChannel<SseItem<IJsonRpcMessage?>>();
 
     private Task? _sseWriteTask;
+    private Utf8JsonWriter? _jsonWriter;
 
     public bool IsConnected => _sseWriteTask?.IsCompleted == false;
 
     public Task RunAsync(CancellationToken cancellationToken)
     {
-        static void WriteJsonRpcMessageToBuffer(SseItem<IJsonRpcMessage?> item, IBufferWriter<byte> writer)
+        void WriteJsonRpcMessageToBuffer(SseItem<IJsonRpcMessage?> item, IBufferWriter<byte> writer)
         {
             if (item.EventType == "endpoint")
             {
@@ -70,7 +68,7 @@ public class SseServerStreamTransport(Stream sseResponseStream) : ITransport
             SingleWriter = false,
         });
 
-    private static Utf8JsonWriter GetUtf8JsonWriter(IBufferWriter<byte> writer)
+    private Utf8JsonWriter GetUtf8JsonWriter(IBufferWriter<byte> writer)
     {
         if (_jsonWriter is null)
         {

--- a/samples/AspNetCoreSseServer/SseServerStreamTransport.cs
+++ b/samples/AspNetCoreSseServer/SseServerStreamTransport.cs
@@ -8,7 +8,7 @@ using McpDotNet.Utils.Json;
 
 namespace AspNetCoreSseServer;
 
-public class AspNetCoreSseMcpTransport(Stream sseResponseStream, ILogger<AspNetCoreSseMcpTransport> logger) : ITransport
+public class SseServerStreamTransport(Stream sseResponseStream) : ITransport
 {
     [ThreadStatic]
     private static Utf8JsonWriter? _jsonWriter;

--- a/samples/AspNetCoreSseServer/Tools/EchoTool.cs
+++ b/samples/AspNetCoreSseServer/Tools/EchoTool.cs
@@ -1,0 +1,14 @@
+﻿using McpDotNet.Server;
+using System.ComponentModel;
+
+namespace TestServerWithHosting.Tools;
+
+[McpToolType]
+public static class EchoTool
+{
+    [McpTool, Description("Echoes the input back to the client.")]
+    public static string Echo(string message)
+    {
+        return "hello " + message;
+    }
+}

--- a/samples/AspNetCoreSseServer/Tools/SampleLlmTool.cs
+++ b/samples/AspNetCoreSseServer/Tools/SampleLlmTool.cs
@@ -1,0 +1,51 @@
+﻿using McpDotNet.Protocol.Types;
+using McpDotNet.Server;
+using System.ComponentModel;
+
+namespace TestServerWithHosting.Tools;
+
+/// <summary>
+/// This tool uses depenency injection and async method
+/// </summary>
+[McpToolType]
+public class SampleLlmTool
+{
+    private readonly IMcpServer _server;
+
+    public SampleLlmTool(IMcpServer server)
+    {
+        _server = server ?? throw new ArgumentNullException(nameof(server));
+    }
+
+    [McpTool("sampleLLM"), Description("Samples from an LLM using MCP's sampling feature")]
+    public async Task<string> SampleLLM(
+        [Description("The prompt to send to the LLM")] string prompt,
+        [Description("Maximum number of tokens to generate")] int maxTokens,
+        CancellationToken cancellationToken)
+    {
+        var samplingParams = CreateRequestSamplingParams(prompt ?? string.Empty, "sampleLLM", maxTokens);
+        var sampleResult = await _server.RequestSamplingAsync(samplingParams, cancellationToken);
+
+        return $"LLM sampling result: {sampleResult.Content.Text}";
+    }
+
+    private static CreateMessageRequestParams CreateRequestSamplingParams(string context, string uri, int maxTokens = 100)
+    {
+        return new CreateMessageRequestParams()
+        {
+            Messages = [new SamplingMessage()
+                {
+                    Role = Role.User,
+                    Content = new Content()
+                    {
+                        Type = "text",
+                        Text = $"Resource {uri} context: {context}"
+                    }
+                }],
+            SystemPrompt = "You are a helpful test server.",
+            MaxTokens = maxTokens,
+            Temperature = 0.7f,
+            IncludeContext = ContextInclusion.ThisServer
+        };
+    }
+}

--- a/samples/AspNetCoreSseServer/appsettings.Development.json
+++ b/samples/AspNetCoreSseServer/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/samples/AspNetCoreSseServer/appsettings.json
+++ b/samples/AspNetCoreSseServer/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/samples/TestServerWithHosting/Program.cs
+++ b/samples/TestServerWithHosting/Program.cs
@@ -17,16 +17,9 @@ try
 
     var builder = Host.CreateApplicationBuilder(args);
     builder.Services.AddSerilog();
-    builder.Services.AddMcpServer(options =>
-    {
-        options.Capabilities = new()
-        {
-            Tools = new()
-        };
-    })
-    .WithStdioServerTransport()
-    .WithTools();
-    //.WithCallToolHandler((r, ct) => Task.FromResult(new McpDotNet.Protocol.Types.CallToolResponse()));
+    builder.Services.AddMcpServer()
+        .WithStdioServerTransport()
+        .WithTools();
 
     var app = builder.Build();
 

--- a/samples/TestServerWithHosting/Program.cs
+++ b/samples/TestServerWithHosting/Program.cs
@@ -8,7 +8,7 @@ Log.Logger = new LoggerConfiguration()
                rollingInterval: RollingInterval.Day,
                outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj}{NewLine}{Exception}")
            .WriteTo.Debug()
-           .WriteTo.Console()
+           .WriteTo.Console(standardErrorFromLevel: Serilog.Events.LogEventLevel.Verbose)
            .CreateLogger();
 
 try
@@ -17,10 +17,16 @@ try
 
     var builder = Host.CreateApplicationBuilder(args);
     builder.Services.AddSerilog();
-    builder.Services.AddMcpServer()
-        .WithStdioServerTransport()
-        .WithTools()
-        .WithCallToolHandler((r, ct) => Task.FromResult(new McpDotNet.Protocol.Types.CallToolResponse()));
+    builder.Services.AddMcpServer(options =>
+    {
+        options.Capabilities = new()
+        {
+            Tools = new()
+        };
+    })
+    .WithStdioServerTransport()
+    .WithTools();
+    //.WithCallToolHandler((r, ct) => Task.FromResult(new McpDotNet.Protocol.Types.CallToolResponse()));
 
     var app = builder.Build();
 

--- a/src/mcpdotnet/Configuration/McpServerBuilderExtensions.Transports.cs
+++ b/src/mcpdotnet/Configuration/McpServerBuilderExtensions.Transports.cs
@@ -1,4 +1,5 @@
 ﻿using McpDotNet.Configuration;
+using McpDotNet.Hosting;
 using McpDotNet.Protocol.Transport;
 using McpDotNet.Utils;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,6 +20,7 @@ public static partial class McpServerBuilderExtensions
         Throw.IfNull(builder);
 
         builder.Services.AddSingleton<IServerTransport, StdioServerTransport>();
+        builder.Services.AddHostedService<McpServerHostedService>();
         return builder;
     }
 
@@ -34,6 +36,7 @@ public static partial class McpServerBuilderExtensions
         }
 
         builder.Services.AddSingleton<IServerTransport, HttpListenerSseServerTransport>();
+        builder.Services.AddHostedService<McpServerHostedService>();
         return builder;
     }
 }

--- a/src/mcpdotnet/Configuration/McpServerOptionsSetup.cs
+++ b/src/mcpdotnet/Configuration/McpServerOptionsSetup.cs
@@ -3,9 +3,9 @@ using McpDotNet.Protocol.Types;
 using McpDotNet.Server;
 using Microsoft.Extensions.Options;
 
-namespace McpDotNet;
+namespace McpDotNet.Configuration;
 
-internal class McpServerOptionsSetup : IConfigureOptions<McpServerOptions>
+internal sealed class McpServerOptionsSetup(IOptions<McpServerHandlers> serverHandlers) : IConfigureOptions<McpServerOptions>
 {
     public void Configure(McpServerOptions options)
     {
@@ -20,5 +20,7 @@ internal class McpServerOptionsSetup : IConfigureOptions<McpServerOptions>
             Name = assemblyName?.Name ?? "McpServer",
             Version = assemblyName?.Version?.ToString() ?? "1.0.0",
         };
+
+        serverHandlers.Value.OverwriteWithSetHandlers(options);
     }
 }

--- a/src/mcpdotnet/Configuration/McpServerOptionsSetup.cs
+++ b/src/mcpdotnet/Configuration/McpServerOptionsSetup.cs
@@ -1,0 +1,24 @@
+﻿using System.Reflection;
+using McpDotNet.Protocol.Types;
+using McpDotNet.Server;
+using Microsoft.Extensions.Options;
+
+namespace McpDotNet;
+
+internal class McpServerOptionsSetup : IConfigureOptions<McpServerOptions>
+{
+    public void Configure(McpServerOptions options)
+    {
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        var assemblyName = Assembly.GetEntryAssembly()?.GetName();
+        options.ServerInfo = new Implementation
+        {
+            Name = assemblyName?.Name ?? "McpServer",
+            Version = assemblyName?.Version?.ToString() ?? "1.0.0",
+        };
+    }
+}

--- a/src/mcpdotnet/Configuration/McpServerServiceCollectionExtension.cs
+++ b/src/mcpdotnet/Configuration/McpServerServiceCollectionExtension.cs
@@ -23,10 +23,10 @@ public static class McpServerServiceCollectionExtension
         services.AddSingleton(services =>
         {
             IServerTransport serverTransport = services.GetRequiredService<IServerTransport>();
-            McpServerOptions options = services.GetRequiredService<McpServerOptions>();
+            IOptions<McpServerOptions> options = services.GetRequiredService<IOptions<McpServerOptions>>();
             ILoggerFactory? loggerFactory = services.GetService<ILoggerFactory>();
 
-            return McpServerFactory.Create(serverTransport, options, loggerFactory, services);
+            return McpServerFactory.Create(serverTransport, options.Value, loggerFactory, services);
         });
 
         services.AddOptions();

--- a/src/mcpdotnet/Configuration/McpServerServiceCollectionExtension.cs
+++ b/src/mcpdotnet/Configuration/McpServerServiceCollectionExtension.cs
@@ -1,7 +1,4 @@
 ﻿using McpDotNet.Configuration;
-using McpDotNet.Hosting;
-using McpDotNet.Protocol.Transport;
-using McpDotNet.Protocol.Types;
 using McpDotNet.Server;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -23,29 +20,11 @@ public static class McpServerServiceCollectionExtension
     /// <returns></returns>
     public static IMcpServerBuilder AddMcpServer(this IServiceCollection services, Action<McpServerOptions>? configureOptions = null)
     {
-        var options = CreateDefaultServerOptions();
-        configureOptions?.Invoke(options);
-
-        return AddMcpServer(services, options);
-    }
-
-    /// <summary>
-    /// Adds the MCP server to the service collection with the provided options.
-    /// </summary>
-    /// <param name="services"></param>
-    /// <param name="serverOptions"></param>
-    /// <returns></returns>
-    public static IMcpServerBuilder AddMcpServer(this IServiceCollection services, McpServerOptions serverOptions)
-    {
-        services.AddSingleton(serverOptions);
-        services.AddHostedService<McpServerHostedService>();
-        services.AddOptions();
         services.AddSingleton(services =>
         {
             IServerTransport serverTransport = services.GetRequiredService<IServerTransport>();
             McpServerOptions options = services.GetRequiredService<McpServerOptions>();
             ILoggerFactory? loggerFactory = services.GetService<ILoggerFactory>();
-
             if (services.GetService<IOptions<McpServerHandlers>>() is { } handlersOptions)
             {
                 options = handlersOptions.Value.OverwriteWithSetHandlers(options);
@@ -54,23 +33,13 @@ public static class McpServerServiceCollectionExtension
             return McpServerFactory.Create(serverTransport, options, loggerFactory, services);
         });
 
-        return new DefaultMcpServerBuilder(services);
-    }
-
-    private static McpServerOptions CreateDefaultServerOptions()
-    {
-        var assemblyName = Assembly.GetEntryAssembly()?.GetName();
-
-        return new McpServerOptions()
+        services.AddOptions();
+        services.AddTransient<IConfigureOptions<McpServerOptions>, McpServerOptionsSetup>();
+        if (configureOptions is not null)
         {
-            ServerInfo = new Implementation() { Name = assemblyName?.Name ?? "McpServer", Version = assemblyName?.Version?.ToString() ?? "1.0.0" },
-            Capabilities = new ServerCapabilities()
-            {
-                Tools = new(),
-                Resources = new(),
-                Prompts = new(),
-            },
-            ProtocolVersion = "2024-11-05"
-        };
+            services.Configure(configureOptions);
+        }
+
+        return new DefaultMcpServerBuilder(services);
     }
 }

--- a/src/mcpdotnet/Configuration/McpServerServiceCollectionExtension.cs
+++ b/src/mcpdotnet/Configuration/McpServerServiceCollectionExtension.cs
@@ -25,10 +25,6 @@ public static class McpServerServiceCollectionExtension
             IServerTransport serverTransport = services.GetRequiredService<IServerTransport>();
             McpServerOptions options = services.GetRequiredService<McpServerOptions>();
             ILoggerFactory? loggerFactory = services.GetService<ILoggerFactory>();
-            if (services.GetService<IOptions<McpServerHandlers>>() is { } handlersOptions)
-            {
-                options = handlersOptions.Value.OverwriteWithSetHandlers(options);
-            }
 
             return McpServerFactory.Create(serverTransport, options, loggerFactory, services);
         });

--- a/src/mcpdotnet/Configuration/McpServerServiceCollectionExtension.cs
+++ b/src/mcpdotnet/Configuration/McpServerServiceCollectionExtension.cs
@@ -1,9 +1,9 @@
 ﻿using McpDotNet.Configuration;
+using McpDotNet.Protocol.Transport;
 using McpDotNet.Server;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System.Reflection;
 
 namespace McpDotNet;
 

--- a/src/mcpdotnet/Protocol/Transport/HttpListenerServerProvider.cs
+++ b/src/mcpdotnet/Protocol/Transport/HttpListenerServerProvider.cs
@@ -235,10 +235,10 @@ internal class HttpListenerServerProvider : IDisposable
             response.StatusCode = 202;
             // Write "accepted" response
             // TODO: Use WriteAsync, add cancellation token and netstandard2.0 support (polyfill?)
-#pragma warning disable CA2016 // Forward the 'CancellationToken' parameter to methods
             byte[] buffer = Encoding.UTF8.GetBytes("Accepted");
-            response.OutputStream.Write(buffer, 0, buffer.Length);
-#pragma warning restore CA2016 // Forward the 'CancellationToken' parameter to methods
+#pragma warning disable CA1835 // Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+            await response.OutputStream.WriteAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+#pragma warning restore CA1835 // Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
         }
         else
         {

--- a/src/mcpdotnet/Protocol/Transport/StdioServerTransport.cs
+++ b/src/mcpdotnet/Protocol/Transport/StdioServerTransport.cs
@@ -6,6 +6,7 @@ using McpDotNet.Utils;
 using McpDotNet.Utils.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 #pragma warning disable CA2208 // Instantiate argument exceptions correctly
 #pragma warning disable CA2213 // Disposable fields should be disposed
@@ -44,6 +45,24 @@ public sealed class StdioServerTransport : TransportBase, IServerTransport
     /// </remarks>
     public StdioServerTransport(McpServerOptions serverOptions, ILoggerFactory? loggerFactory = null)
         : this(GetServerName(serverOptions), loggerFactory)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StdioServerTransport"/> class, using
+    /// <see cref="Console.In"/> and <see cref="Console.Out"/> for input and output streams.
+    /// </summary>
+    /// <param name="serverOptions">The server options.</param>
+    /// <param name="loggerFactory">Optional logger factory used for logging employed by the transport.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="serverOptions"/> is <see langword="null"/> or contains a null name.</exception>
+    /// <remarks>
+    /// <para>
+    /// By default, no logging is performed. If a <paramref name="loggerFactory"/> is supplied, it must not log
+    /// to <see cref="Console.Out"/>, as that will interfere with the transport's output.
+    /// </para>
+    /// </remarks>
+    public StdioServerTransport(IOptions<McpServerOptions> serverOptions, ILoggerFactory? loggerFactory = null)
+        : this(GetServerName(serverOptions.Value), loggerFactory)
     {
     }
 

--- a/src/mcpdotnet/Server/McpServer.cs
+++ b/src/mcpdotnet/Server/McpServer.cs
@@ -12,7 +12,7 @@ namespace McpDotNet.Server;
 /// <inheritdoc />
 internal sealed class McpServer : McpJsonRpcEndpoint, IMcpServer
 {
-    private readonly IServerTransport _serverTransport;
+    private readonly IServerTransport? _serverTransport;
     private readonly McpServerOptions _options;
     private volatile bool _isInitializing;
     private readonly ILogger _logger;
@@ -26,12 +26,12 @@ internal sealed class McpServer : McpJsonRpcEndpoint, IMcpServer
     /// <param name="loggerFactory">Logger factory to use for logging</param>
     /// <param name="serviceProvider">Optional service provider to use for dependency injection</param>
     /// <exception cref="McpServerException"></exception>
-    public McpServer(IServerTransport transport, McpServerOptions options, ILoggerFactory? loggerFactory, IServiceProvider? serviceProvider)
+    public McpServer(ITransport transport, McpServerOptions options, ILoggerFactory loggerFactory, IServiceProvider? serviceProvider)
         : base(transport, loggerFactory)
     {
         Throw.IfNull(options);
 
-        _serverTransport = transport;
+        _serverTransport = transport as IServerTransport;
         _options = options;
         _logger = (ILogger?)loggerFactory?.CreateLogger<McpServer>() ?? NullLogger.Instance;
         ServerInstructions = options.ServerInstructions;
@@ -86,8 +86,11 @@ internal sealed class McpServer : McpJsonRpcEndpoint, IMcpServer
         {
             CancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
-            // Start listening for messages
-            await _serverTransport.StartListeningAsync(CancellationTokenSource.Token).ConfigureAwait(false);
+            if (_serverTransport is not null)
+            {
+                // Start listening for messages
+                await _serverTransport.StartListeningAsync(CancellationTokenSource.Token).ConfigureAwait(false);
+            }
 
             // Start processing messages
             MessageProcessingTask = ProcessMessagesAsync(CancellationTokenSource.Token);

--- a/src/mcpdotnet/Server/McpServer.cs
+++ b/src/mcpdotnet/Server/McpServer.cs
@@ -26,7 +26,7 @@ internal sealed class McpServer : McpJsonRpcEndpoint, IMcpServer
     /// <param name="loggerFactory">Logger factory to use for logging</param>
     /// <param name="serviceProvider">Optional service provider to use for dependency injection</param>
     /// <exception cref="McpServerException"></exception>
-    public McpServer(ITransport transport, McpServerOptions options, ILoggerFactory loggerFactory, IServiceProvider? serviceProvider)
+    public McpServer(ITransport transport, McpServerOptions options, ILoggerFactory? loggerFactory, IServiceProvider? serviceProvider)
         : base(transport, loggerFactory)
     {
         Throw.IfNull(options);

--- a/src/mcpdotnet/Server/McpServerFactory.cs
+++ b/src/mcpdotnet/Server/McpServerFactory.cs
@@ -23,7 +23,7 @@ public static class McpServerFactory
     /// <exception cref="ArgumentNullException"><paramref name="serverTransport"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentNullException"><paramref name="serverOptions"/> is <see langword="null"/>.</exception>
     public static IMcpServer Create(
-        IServerTransport serverTransport,
+        ITransport serverTransport,
         McpServerOptions serverOptions,
         ILoggerFactory? loggerFactory = null,
         IServiceProvider? serviceProvider = null)

--- a/src/mcpdotnet/Server/McpServerHandlers.cs
+++ b/src/mcpdotnet/Server/McpServerHandlers.cs
@@ -118,9 +118,9 @@ public sealed class McpServerHandlers
                 };
         }
 
-        return options with
+        return new McpServerOptions
         {
-            GetCompletionHandler = GetCompletionHandler ?? options.GetCompletionHandler,
+            ServerInfo = options.ServerInfo,
             Capabilities = options.Capabilities is null ?
                 new()
                 {
@@ -134,6 +134,10 @@ public sealed class McpServerHandlers
                     Resources = resourcesCapability,
                     Tools = toolsCapability,
                 },
+            ProtocolVersion = options.ProtocolVersion,
+            InitializationTimeout = options.InitializationTimeout,
+            ServerInstructions = options.ServerInstructions,
+            GetCompletionHandler = GetCompletionHandler ?? options.GetCompletionHandler,
         };
     }
 }

--- a/src/mcpdotnet/Server/McpServerHandlers.cs
+++ b/src/mcpdotnet/Server/McpServerHandlers.cs
@@ -57,7 +57,7 @@ public sealed class McpServerHandlers
     /// </summary>
     /// <param name="options"></param>
     /// <returns></returns>
-    internal McpServerOptions OverwriteWithSetHandlers(McpServerOptions options)
+    internal void OverwriteWithSetHandlers(McpServerOptions options)
     {
         PromptsCapability? promptsCapability = options.Capabilities?.Prompts;
         if (ListPromptsHandler is not null || GetPromptHandler is not null)
@@ -118,26 +118,20 @@ public sealed class McpServerHandlers
                 };
         }
 
-        return new McpServerOptions
-        {
-            ServerInfo = options.ServerInfo,
-            Capabilities = options.Capabilities is null ?
-                new()
-                {
-                    Prompts = promptsCapability,
-                    Resources = resourcesCapability,
-                    Tools = toolsCapability,
-                } :
-                options.Capabilities with
-                {
-                    Prompts = promptsCapability,
-                    Resources = resourcesCapability,
-                    Tools = toolsCapability,
-                },
-            ProtocolVersion = options.ProtocolVersion,
-            InitializationTimeout = options.InitializationTimeout,
-            ServerInstructions = options.ServerInstructions,
-            GetCompletionHandler = GetCompletionHandler ?? options.GetCompletionHandler,
-        };
+        options.Capabilities = options.Capabilities is null ?
+            new()
+            {
+                Prompts = promptsCapability,
+                Resources = resourcesCapability,
+                Tools = toolsCapability,
+            } :
+            options.Capabilities with
+            {
+                Prompts = promptsCapability,
+                Resources = resourcesCapability,
+                Tools = toolsCapability,
+            };
+
+        options.GetCompletionHandler = GetCompletionHandler ?? options.GetCompletionHandler;
     }
 }

--- a/src/mcpdotnet/Server/McpServerOptions.cs
+++ b/src/mcpdotnet/Server/McpServerOptions.cs
@@ -40,5 +40,5 @@ public class McpServerOptions
     /// Gets or sets the handler for get completion requests.
     /// </summary>
     [JsonIgnore]
-    public Func<RequestContext<CompleteRequestParams>, CancellationToken, Task<CompleteResult>>? GetCompletionHandler { get; init; }
+    public Func<RequestContext<CompleteRequestParams>, CancellationToken, Task<CompleteResult>>? GetCompletionHandler { get; set; }
 }

--- a/src/mcpdotnet/Server/McpServerOptions.cs
+++ b/src/mcpdotnet/Server/McpServerOptions.cs
@@ -9,32 +9,32 @@ namespace McpDotNet.Server;
 /// protocol version.
 /// <see href="https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/lifecycle/">See the protocol specification for details on capability negotiation</see>
 /// </summary>
-public record McpServerOptions
+public class McpServerOptions
 {
     /// <summary>
     /// Information about this server implementation.
     /// </summary>
-    public required Implementation ServerInfo { get; init; }
+    public required Implementation ServerInfo { get; set; }
 
     /// <summary>
     /// Server capabilities to advertise to the server.
     /// </summary>
-    public ServerCapabilities? Capabilities { get; init; }
+    public ServerCapabilities? Capabilities { get; set; }
 
     /// <summary>
     /// Protocol version to request from the server.
     /// </summary>
-    public string ProtocolVersion { get; init; } = "2024-11-05";
+    public string ProtocolVersion { get; set; } = "2024-11-05";
 
     /// <summary>
     /// Timeout for initialization sequence.
     /// </summary>
-    public TimeSpan InitializationTimeout { get; init; } = TimeSpan.FromSeconds(60);
+    public TimeSpan InitializationTimeout { get; set; } = TimeSpan.FromSeconds(60);
 
     /// <summary>
     /// Optional server instructions to send to clients
     /// </summary>
-    public string ServerInstructions { get; init; } = string.Empty;
+    public string ServerInstructions { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the handler for get completion requests.

--- a/src/mcpdotnet/mcpdotnet.csproj
+++ b/src/mcpdotnet/mcpdotnet.csproj
@@ -35,6 +35,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="McpDotNet.Tests" />
+    <InternalsVisibleTo Include="AspNetCoreSseServer" />
   </ItemGroup>
   
   <ItemGroup>

--- a/tests/mcpdotnet.Tests/Server/McpServerTests.cs
+++ b/tests/mcpdotnet.Tests/Server/McpServerTests.cs
@@ -280,9 +280,9 @@ public class McpServerTests
         await Can_Handle_Requests(
             serverCapabilities: null,
             method: "completion/complete",
-            configureOptions: options => options with
+            configureOptions: options =>
             {
-                GetCompletionHandler = (request, ct) =>
+                options.GetCompletionHandler = (request, ct) =>
                     Task.FromResult(new CompleteResult
                     {
                         Completion = new()
@@ -291,7 +291,7 @@ public class McpServerTests
                             Total = 2,
                             HasMore = true
                         }
-                    })
+                    });
             },
             assertResult: response =>
             {
@@ -518,14 +518,11 @@ public class McpServerTests
         await Throws_Exception_If_No_Handler_Assigned(new ServerCapabilities { Tools = new() }, "tools/call", "CallTool handler not configured");
     }
 
-    private async Task Can_Handle_Requests(ServerCapabilities? serverCapabilities, string method, Func<McpServerOptions, McpServerOptions>? configureOptions, Action<object> assertResult)
+    private async Task Can_Handle_Requests(ServerCapabilities? serverCapabilities, string method, Action<McpServerOptions>? configureOptions, Action<object> assertResult)
     {
         await using var transport = new TestServerTransport();
         var options = CreateOptions(serverCapabilities);
-        if (configureOptions is not null)
-        {
-            options = configureOptions(options);
-        }
+        configureOptions?.Invoke(options);
 
         await using var server = new McpServer(transport, options, _loggerFactory.Object, _serviceProvider);
 

--- a/tests/mcpdotnet.Tests/SseServerIntegrationTestFixture.cs
+++ b/tests/mcpdotnet.Tests/SseServerIntegrationTestFixture.cs
@@ -11,7 +11,6 @@ public class SseServerIntegrationTestFixture : IDisposable
     private Process _process;
 
     public ILoggerFactory LoggerFactory { get; }
-    public McpClientFactory Factory { get; }
     public McpClientOptions DefaultOptions { get; }
     public McpServerConfig DefaultConfig { get; }
 
@@ -24,7 +23,6 @@ public class SseServerIntegrationTestFixture : IDisposable
         DefaultOptions = new()
         {
             ClientInfo = new() { Name = "IntegrationTestClient", Version = "1.0.0" },
-            Capabilities = new() { Sampling = new(), Roots = new() }
         };
 
         DefaultConfig = new McpServerConfig
@@ -35,13 +33,6 @@ public class SseServerIntegrationTestFixture : IDisposable
             TransportOptions = [],
             Location = "http://localhost:3001/sse"
         };
-
-        // Inject the mock transport into the factory
-        Factory = new McpClientFactory(
-            [DefaultConfig],
-            DefaultOptions,
-            LoggerFactory
-        );
 
         Start();
     }
@@ -70,7 +61,7 @@ public class SseServerIntegrationTestFixture : IDisposable
     {
         try
         {
-            var client = Factory.GetClientAsync("test_server").Result;
+            var client = McpClientFactory.CreateAsync(DefaultConfig, DefaultOptions, loggerFactory: LoggerFactory).GetAwaiter().GetResult();
             client.DisposeAsync().AsTask().Wait();
             LoggerFactory?.Dispose();
         }


### PR DESCRIPTION
This PR demonstrates how you could use a modified `AddMcpServer` API in ASP.NET Core sample app to implement a `MapMcpSse()` API (name tbd) that exposes tools registered using `.WithTools()`. It's inspired a bit by https://github.com/modelcontextprotocol/servers/blob/7034c3d13c72eaf2f188908e9cd54e6d6b091272/src/everything/sse.ts. It doesn't handle anything advanced like concurrent sessions yet.

I haven't added any projects other than the new sample app for now. However, the `AspNetCoreSseMcpTransport` could be renamed to something like `ResponseStreamSseTransport` and moved into the main mcpdotnet package. It wouldn't require adding any ASP.NET Core dependencies, but we would need to update the System.Net.ServerSentEvents dependency to be at least 10.0.0-preview.1.25080.5 which might be awkward for a non-preview package.

Contributes to #24