### PR TITLE
add Semantic Kernel server extensions project

### DIFF
--- a/mcpdotnet.sln
+++ b/mcpdotnet.sln
@@ -23,6 +23,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{02EA
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{2A77AF5C-138A-4EBB-9A13-9205DCD67928}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SemanticKernelIntegration", "samples\SemanticKernelIntegration\SemanticKernelIntegration.csproj", "{556329F9-1531-4697-9907-6A176A5387D5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "McpDotNet.Extensions.SemanticKernel", "src\McpDotNet.Extensions.SemanticKernel\McpDotNet.Extensions.SemanticKernel.csproj", "{027D759A-5027-4003-BD45-F7811478FE02}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -61,6 +65,14 @@ Global
 		{6499876E-2F76-44A8-B6EB-5B889C6E9B7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6499876E-2F76-44A8-B6EB-5B889C6E9B7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6499876E-2F76-44A8-B6EB-5B889C6E9B7F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{556329F9-1531-4697-9907-6A176A5387D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{556329F9-1531-4697-9907-6A176A5387D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{556329F9-1531-4697-9907-6A176A5387D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{556329F9-1531-4697-9907-6A176A5387D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{027D759A-5027-4003-BD45-F7811478FE02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{027D759A-5027-4003-BD45-F7811478FE02}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{027D759A-5027-4003-BD45-F7811478FE02}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{027D759A-5027-4003-BD45-F7811478FE02}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -72,6 +84,8 @@ Global
 		{7C229573-A085-4ECC-8131-958CDA2BE731} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{67BEF596-AD39-4BDD-B505-31DE7FF0C8D2} = {2A77AF5C-138A-4EBB-9A13-9205DCD67928}
 		{6499876E-2F76-44A8-B6EB-5B889C6E9B7F} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{556329F9-1531-4697-9907-6A176A5387D5} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{027D759A-5027-4003-BD45-F7811478FE02} = {B32C0405-5A1A-4674-BA72-8DA7AB02828A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {384A3888-751F-4D75-9AE5-587330582D89}

--- a/samples/SemanticKernelIntegration/Plugins/CalculatorPlugin.cs
+++ b/samples/SemanticKernelIntegration/Plugins/CalculatorPlugin.cs
@@ -1,0 +1,73 @@
+using System;
+using System.ComponentModel;
+using Microsoft.SemanticKernel;
+using Serilog;
+
+namespace SemanticKernelIntegration.Plugins;
+
+/// <summary>
+/// Basic calculator plugin
+/// </summary>
+public class CalculatorPlugin
+{
+    /// <summary>
+    /// Adds two numbers together
+    /// </summary>
+    /// <param name="a">First number</param>
+    /// <param name="b">Second number</param>
+    /// <returns>The sum of the two numbers</returns>
+    [KernelFunction("add")]
+    [Description("Add two numbers together")]
+    public double Add(
+        [Description("The first number to add")] double a,
+        [Description("The second number to add")] double b)
+    {
+        Log.Debug("Add function called with a: {A}, b: {B}", a, b);
+        var result = a + b;
+        Log.Information("Addition result: {A} + {B} = {Result}", a, b, result);
+        return result;
+    }
+    
+    /// <summary>
+    /// Multiplies two numbers
+    /// </summary>
+    /// <param name="a">First number</param>
+    /// <param name="b">Second number</param>
+    /// <returns>The product of the two numbers</returns>
+    [KernelFunction("multiply")]
+    [Description("Multiply two numbers together")]
+    public double Multiply(
+        [Description("The first number to multiply")] double a,
+        [Description("The second number to multiply")] double b)
+    {
+        Log.Debug("Multiply function called with a: {A}, b: {B}", a, b);
+        var result = a * b;
+        Log.Information("Multiplication result: {A} * {B} = {Result}", a, b, result);
+        return result;
+    }
+    
+    /// <summary>
+    /// Divides two numbers
+    /// </summary>
+    /// <param name="a">Dividend (number to be divided)</param>
+    /// <param name="b">Divisor</param>
+    /// <returns>The result of dividing a by b</returns>
+    [KernelFunction("divide")]
+    [Description("Divide the first number by the second number")]
+    public string Divide(
+        [Description("The dividend (number to be divided)")] double a,
+        [Description("The divisor")] double b)
+    {
+        Log.Debug("Divide function called with a: {A}, b: {B}", a, b);
+        
+        if (b == 0)
+        {
+            Log.Warning("Division by zero attempted with a: {A}", a);
+            return "Error: Cannot divide by zero";
+        }
+        
+        var result = a / b;
+        Log.Information("Division result: {A} / {B} = {Result}", a, b, result);
+        return result.ToString();
+    }
+} 

--- a/samples/SemanticKernelIntegration/Plugins/TimePlugin.cs
+++ b/samples/SemanticKernelIntegration/Plugins/TimePlugin.cs
@@ -1,0 +1,72 @@
+using System;
+using System.ComponentModel;
+using Microsoft.SemanticKernel;
+using Serilog;
+
+namespace SemanticKernelIntegration.Plugins;
+
+/// <summary>
+/// Time-related plugin functions
+/// </summary>
+public class TimePlugin
+{
+    /// <summary>
+    /// Gets the current UTC time
+    /// </summary>
+    /// <returns>The current UTC time formatted as RFC1123</returns>
+    [KernelFunction]
+    [Description("Gets the current time in UTC format")]
+    public string GetCurrentUtcTime()
+    {
+        Log.Debug("GetCurrentUtcTime function called");
+        var result = DateTime.UtcNow.ToString("R");
+        Log.Information("Current UTC time: {UtcTime}", result);
+        return result;
+    }
+    
+    /// <summary>
+    /// Gets the current local time
+    /// </summary>
+    /// <returns>The current local time as a string</returns>
+    [KernelFunction]
+    [Description("Gets the current local time")]
+    public string GetLocalTime()
+    {
+        Log.Debug("GetLocalTime function called");
+        var result = DateTime.Now.ToString("F");
+        Log.Information("Current local time: {LocalTime}", result);
+        return result;
+    }
+    
+    /// <summary>
+    /// Calculates the time difference between two dates
+    /// </summary>
+    /// <param name="startDate">The starting date in ISO format (e.g., 2023-01-01)</param>
+    /// <param name="endDate">The ending date in ISO format (e.g., 2023-12-31)</param>
+    /// <returns>The time difference in days</returns>
+    [KernelFunction]
+    [Description("Calculates time difference between two dates")]
+    public string CalculateTimeDifference(
+        [Description("Starting date in ISO format (e.g., 2023-01-01)")] string startDate,
+        [Description("Ending date in ISO format (e.g., 2023-12-31)")] string endDate)
+    {
+        Log.Debug("CalculateTimeDifference function called with startDate: {StartDate}, endDate: {EndDate}", startDate, endDate);
+        
+        try
+        {
+            var start = DateTime.Parse(startDate);
+            var end = DateTime.Parse(endDate);
+            var difference = end - start;
+            
+            var result = $"The difference between {startDate} and {endDate} is {difference.Days} days.";
+            Log.Information("Time difference calculated: {Result}", result);
+            return result;
+        }
+        catch (Exception ex)
+        {
+            var errorMessage = $"Error calculating time difference: {ex.Message}";
+            Log.Error(ex, "Failed to calculate time difference between {StartDate} and {EndDate}", startDate, endDate);
+            return errorMessage;
+        }
+    }
+} 

--- a/samples/SemanticKernelIntegration/Plugins/WeatherPlugin.cs
+++ b/samples/SemanticKernelIntegration/Plugins/WeatherPlugin.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using Microsoft.SemanticKernel;
+using Serilog;
+
+namespace SemanticKernelIntegration.Plugins;
+
+/// <summary>
+/// Weather information plugin
+/// </summary>
+public class WeatherPlugin
+{
+    // Simulated weather data
+    private readonly Dictionary<string, (double Temperature, string Condition)> _cityWeather = new()
+    {
+        { "new york", (21.5, "Partly Cloudy") },
+        { "london", (15.2, "Rainy") },
+        { "tokyo", (28.0, "Sunny") },
+        { "paris", (19.8, "Clear") },
+        { "sydney", (25.5, "Sunny") },
+        { "berlin", (17.3, "Cloudy") },
+        { "moscow", (10.1, "Snowy") },
+        { "dubai", (36.2, "Hot and Sunny") },
+        { "rio de janeiro", (30.5, "Humid") },
+        { "cape town", (22.7, "Windy") }
+    };
+    
+    /// <summary>
+    /// Gets the current weather for a specified city
+    /// </summary>
+    /// <param name="city">The name of the city</param>
+    /// <returns>The current weather information for the city</returns>
+    [KernelFunction("get_weather")]
+    [Description("Get the current weather for a specified city")]
+    public string GetWeather(
+        [Description("The name of the city")] string city)
+    {
+        Log.Debug("GetWeather function called for city: {City}", city);
+        var normalizedCity = city.Trim().ToLowerInvariant();
+        
+        if (_cityWeather.TryGetValue(normalizedCity, out var weather))
+        {
+            var cityName = char.ToUpper(normalizedCity[0]) + normalizedCity.Substring(1);
+            var result = $"The current weather in {cityName} is {weather.Temperature}°C and {weather.Condition}.";
+            Log.Information("Weather information retrieved for {City}: {Temperature}°C, {Condition}", 
+                cityName, weather.Temperature, weather.Condition);
+            return result;
+        }
+        
+        Log.Warning("Weather data not found for city: {City}", city);
+        return $"Sorry, I don't have weather data for {city}.";
+    }
+    
+    /// <summary>
+    /// Lists all cities for which weather data is available
+    /// </summary>
+    /// <returns>A comma-separated list of cities</returns>
+    [KernelFunction("list_cities")]
+    [Description("List all cities for which weather data is available")]
+    public string ListAvailableCities()
+    {
+        Log.Debug("ListAvailableCities function called");
+        
+        var cities = _cityWeather.Keys
+            .Select(city => char.ToUpper(city[0]) + city.Substring(1))
+            .OrderBy(city => city);
+        
+        var cityList = string.Join(", ", cities);
+        Log.Information("Available cities list generated with {Count} cities", cities.Count());
+        return $"Available cities: {cityList}";
+    }
+    
+    /// <summary>
+    /// Gets a weather forecast for the next few days
+    /// </summary>
+    /// <param name="city">The name of the city</param>
+    /// <param name="days">Number of days for the forecast (1-5)</param>
+    /// <returns>A simulated weather forecast for the specified number of days</returns>
+    [KernelFunction("get_forecast")]
+    [Description("Get a weather forecast for a city for the specified number of days")]
+    public string GetForecast(
+        [Description("The name of the city")] string city,
+        [Description("Number of days for the forecast (1-5)")] int days = 3)
+    {
+        Log.Debug("GetForecast function called for city: {City}, days: {Days}", city, days);
+        
+        var normalizedCity = city.Trim().ToLowerInvariant();
+        
+        if (!_cityWeather.TryGetValue(normalizedCity, out var currentWeather))
+        {
+            Log.Warning("Weather data not found for city: {City}", city);
+            return $"Sorry, I don't have weather data for {city}.";
+        }
+        
+        if (days < 1 || days > 5)
+        {
+            Log.Warning("Invalid number of days requested: {Days}. Must be between 1 and 5.", days);
+            return "Please specify between 1 and 5 days for the forecast.";
+        }
+        
+        // Generate a simple simulated forecast based on current conditions
+        var random = new Random();
+        var forecast = new List<string>();
+        var conditions = new[] { "Sunny", "Cloudy", "Rainy", "Partly Cloudy", "Clear", "Stormy" };
+        
+        var cityName = char.ToUpper(normalizedCity[0]) + normalizedCity.Substring(1);
+        forecast.Add($"Weather forecast for {cityName}:");
+        
+        Log.Information("Generating {Days}-day forecast for {City}", days, cityName);
+        
+        for (int i = 0; i < days; i++)
+        {
+            var date = DateTime.Now.AddDays(i).ToString("dddd, MMMM d");
+            var tempVariation = random.NextDouble() * 6 - 3; // -3 to +3 degrees variation
+            var temp = Math.Round(currentWeather.Temperature + tempVariation, 1);
+            var condition = conditions[random.Next(conditions.Length)];
+            
+            forecast.Add($"  {date}: {temp}°C, {condition}");
+            
+            Log.Debug("Forecast for {City} on {Date}: {Temperature}°C, {Condition}", 
+                cityName, date, temp, condition);
+        }
+        
+        var result = string.Join("\n", forecast);
+        Log.Information("Forecast generated for {City} for {Days} days", cityName, days);
+        
+        return result;
+    }
+} 

--- a/samples/SemanticKernelIntegration/Program.cs
+++ b/samples/SemanticKernelIntegration/Program.cs
@@ -1,0 +1,114 @@
+using McpDotNet;
+using McpDotNet.Extensions.SemanticKernel;
+using McpDotNet.Protocol.Types;
+using Microsoft.Extensions.Hosting;
+using Microsoft.SemanticKernel;
+using Serilog;
+using Serilog.Events;
+using SemanticKernelIntegration.Plugins;
+
+namespace SemanticKernelIntegration;
+
+/// <summary>
+/// Sample application demonstrating Semantic Kernel integration with MCP
+/// </summary>
+class Program
+{
+    static async Task Main(string[] args)
+    {
+        // Configure Serilog
+        ConfigureSerilog();
+
+        try
+        {
+            Log.Information("Starting Semantic Kernel Integration sample...");
+
+            // 1. Set up the Semantic Kernel
+            var kernel = ConfigureSemanticKernel();
+
+            // 2. Create an application builder
+            var builder = Host.CreateEmptyApplicationBuilder(settings: null);
+
+            // 3. Configure MCP server
+            builder.Services
+                .AddMcpServer()
+                .WithSemanticKernel(kernel)
+                .WithListPromptsHandler((_, _) => Task.FromResult(new ListPromptsResult()))
+                .WithGetPromptHandler((_, _) => Task.FromResult(new GetPromptResult()))
+                .WithListResourcesHandler((_, _) => Task.FromResult(new ListResourcesResult()))
+                .WithReadResourceHandler((_, _) => Task.FromResult(new ReadResourceResult()))
+                .WithStdioServerTransport();
+
+            // 4. Add Serilog to the service collection
+            builder.Services.AddSerilog();
+
+            // 5. Build the host
+            var host = builder.Build();
+
+            // 6. Start the host
+            await host.StartAsync();
+
+            Log.Information("MCP server started successfully. Waiting for requests...");
+
+            // Run until process is stopped by the client (parent process)
+            await Task.Delay(Timeout.Infinite);
+        }
+        catch (Exception ex)
+        {
+            Log.Fatal(ex, "A critical error occurred during sample execution");
+        }
+        finally
+        {
+            // Ensure all logs are flushed before the application exits
+            await Log.CloseAndFlushAsync();
+        }
+    }
+
+    /// <summary>
+    /// Configures Serilog with file, debug, and stderr sinks
+    /// </summary>
+    private static void ConfigureSerilog()
+    {
+        // Create logs directory if it doesn't exist
+        var logsDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "logs");
+        if (!Directory.Exists(logsDirectory))
+        {
+            Directory.CreateDirectory(logsDirectory);
+        }
+
+        // Configure Serilog
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Verbose() // Capture all log levels
+            .WriteTo.File(
+                Path.Combine(logsDirectory, "SemanticKernelIntegration_.log"),
+                rollingInterval: RollingInterval.Day,
+                outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj}{NewLine}{Exception}")
+            .WriteTo.Debug()
+            .WriteTo.Console(
+                standardErrorFromLevel: LogEventLevel.Verbose, // Send all logs to stderr
+                outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
+            .CreateLogger();
+    }
+
+    /// <summary>
+    /// Configures the Semantic Kernel with plugins
+    /// </summary>
+    private static Kernel ConfigureSemanticKernel()
+    {
+        var skBuilder = Kernel.CreateBuilder();
+
+        // Set up Serilog for Semantic Kernel
+        skBuilder.Services.AddSerilog();
+
+        Log.Information("Registering plugins with Semantic Kernel...");
+
+        // Register plugins with the kernel
+        skBuilder.Plugins.AddFromType<TimePlugin>();
+        skBuilder.Plugins.AddFromType<CalculatorPlugin>();
+        skBuilder.Plugins.AddFromType<WeatherPlugin>();
+
+        Log.Information("Plugins registered successfully");
+
+        return skBuilder.Build();
+    }
+}

--- a/samples/SemanticKernelIntegration/SemanticKernelIntegration.csproj
+++ b/samples/SemanticKernelIntegration/SemanticKernelIntegration.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\mcpdotnet\mcpdotnet.csproj" />
+    <ProjectReference Include="..\..\src\McpDotNet.Extensions.SemanticKernel\McpDotNet.Extensions.SemanticKernel.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.3" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.41.0" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.205.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="16.205.1" />
+    <PackageReference Include="Serilog" Version="4.2.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageReference Include="System.Linq" Version="4.3.0" />
+  </ItemGroup>
+
+</Project> 

--- a/src/McpDotNet.Extensions.SemanticKernel/McpDotNet.Extensions.SemanticKernel.csproj
+++ b/src/McpDotNet.Extensions.SemanticKernel/McpDotNet.Extensions.SemanticKernel.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>McpDotNet.Extensions.SemanticKernel</RootNamespace>
+    <AssemblyName>McpDotNet.Extensions.SemanticKernel</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>McpDotNet.Extensions.SemanticKernel</PackageId>
+    <Authors>mcpdotnet Contributors</Authors>
+    <Description>Semantic Kernel integration for the mcpdotnet library</Description>
+    <PackageTags>mcp;semantic-kernel;ai;llm</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\mcpdotnet\mcpdotnet.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.41.0" />
+  </ItemGroup>
+
+</Project> 

--- a/src/McpDotNet.Extensions.SemanticKernel/McpServerBuilderExtensions.cs
+++ b/src/McpDotNet.Extensions.SemanticKernel/McpServerBuilderExtensions.cs
@@ -1,0 +1,216 @@
+using System.Text.Json;
+using McpDotNet.Configuration;
+using McpDotNet.Protocol.Types;
+using McpDotNet.Server;
+using Microsoft.SemanticKernel;
+
+namespace McpDotNet.Extensions.SemanticKernel;
+
+/// <summary>
+/// Extension methods to integrate Semantic Kernel with MCP server
+/// </summary>
+public static class McpServerBuilderSemanticKernelExtensions
+{
+    /// <summary>
+    /// Adds a Semantic Kernel instance to the server, exposing all its registered plugins as MCP tools.
+    /// </summary>
+    /// <param name="builder">The builder instance.</param>
+    /// <param name="kernel">The Semantic Kernel instance containing the plugins to expose.</param>
+    /// <returns>The builder instance.</returns>
+    public static IMcpServerBuilder WithSemanticKernel(this IMcpServerBuilder builder, Kernel kernel)
+    {
+        if (builder is null)
+            throw new ArgumentNullException(nameof(builder));
+
+        if (kernel is null)
+            throw new ArgumentNullException(nameof(kernel));
+
+        var tools = new List<Tool>();
+        Dictionary<string, Func<RequestContext<CallToolRequestParams>, CancellationToken, Task<CallToolResponse>>> callbacks = [];
+
+        // Process all plugins and their functions
+        foreach (var plugin in kernel.Plugins)
+        {
+            var pluginName = plugin.Name;
+            
+            // Iterate through functions using the IEnumerable<KernelFunction> implementation
+            foreach (var function in plugin)
+            {
+                var functionName = function.Name;
+
+                // Get description from the function metadata
+                var description = function.Metadata.Description;
+                
+                // Create tool schema from the function's metadata
+                var tool = CreateToolFromKernelFunction(function.Metadata, pluginName);
+                tools.Add(tool);
+
+                // Register callback to invoke the function via kernel
+                callbacks.Add(tool.Name, async (request, cancellationToken) => 
+                    await CallKernelFunction(kernel, pluginName, functionName, request, cancellationToken).ConfigureAwait(false));
+            }
+        }
+
+        if (tools.Count == 0)
+            throw new ArgumentException("No functions found in the provided Kernel.", nameof(kernel));
+
+        builder.WithListToolsHandler((_, _) => Task.FromResult(new ListToolsResult() { Tools = tools }));
+
+        builder.WithCallToolHandler(async (request, cancellationToken) =>
+        {
+            if (request.Params != null && callbacks.TryGetValue(request.Params.Name, out var callback))
+                return await callback(request, cancellationToken).ConfigureAwait(false);
+
+            throw new McpServerException($"Unknown tool: {request.Params?.Name}");
+        });
+
+        return builder;
+    }
+    
+    /// <summary>
+    /// Creates a Tool object from a Semantic Kernel function
+    /// </summary>
+    private static Tool CreateToolFromKernelFunction(KernelFunctionMetadata function, string pluginName)
+    {
+        var parameters = function.Parameters;
+        Dictionary<string, JsonSchemaProperty> properties = [];
+        List<string>? requiredProperties = null;
+
+        foreach (var parameter in parameters)
+        {
+            properties.Add(parameter.Name, new JsonSchemaProperty()
+            {
+                Type = GetParameterType(parameter.ParameterType!),
+                Description = parameter.Description,
+            });
+
+            if (parameter.IsRequired)
+            {
+                requiredProperties ??= [];
+                requiredProperties.Add(parameter.Name);
+            }
+        }
+
+        return new Tool()
+        {
+            Name = string.IsNullOrEmpty(pluginName) 
+                ? function.Name 
+                : $"{pluginName}-{function.Name}",
+            Description = function.Description,
+            InputSchema = new JsonSchema()
+            {
+                Type = "object",
+                Properties = properties,
+                Required = requiredProperties
+            }
+        };
+    }
+
+    /// <summary>
+    /// Calls a Semantic Kernel function through the kernel instance
+    /// </summary>
+    private static async Task<CallToolResponse> CallKernelFunction(
+        Kernel kernel, 
+        string pluginName, 
+        string functionName, 
+        RequestContext<CallToolRequestParams> request, 
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Create arguments from the request
+        var arguments = new KernelArguments();
+
+        // Add all arguments from the request
+        if (request.Params?.Arguments != null)
+        {
+            foreach (var arg in request.Params.Arguments)
+            {
+                if (arg.Value is JsonElement element)
+                {
+                    // Handle JsonElement based on its type
+                    switch (element.ValueKind)
+                    {
+                        case JsonValueKind.String:
+                            arguments[arg.Key] = element.GetString();
+                            break;
+                        case JsonValueKind.Number:
+                            if (element.TryGetInt32(out var intValue))
+                                arguments[arg.Key] = intValue;
+                            else if (element.TryGetDouble(out var doubleValue))
+                                arguments[arg.Key] = doubleValue;
+                            break;
+                        case JsonValueKind.True:
+                        case JsonValueKind.False:
+                            arguments[arg.Key] = element.GetBoolean();
+                            break;
+                        case JsonValueKind.Array:
+                        case JsonValueKind.Object:
+                            // Use the JsonElement directly and let Semantic Kernel handle deserialization
+                            arguments[arg.Key] = element;
+                            break;
+                        case JsonValueKind.Null:
+                            arguments[arg.Key] = null;
+                            break;
+                    }
+                }
+                else
+                {
+                    arguments[arg.Key] = arg.Value;
+                }
+            }
+        }
+
+        try
+        {
+            // Invoke the function using the kernel
+            var result = await kernel.InvokeAsync(pluginName, functionName, arguments, cancellationToken).ConfigureAwait(false);
+            
+            // Process the result
+            return ProcessFunctionResult(result.GetValue<object>());
+        }
+        catch (Exception ex)
+        {
+            // Handle any errors during function execution
+            return new CallToolResponse 
+            { 
+                Content = [new Content() { Text = $"Error executing function: {ex.Message}", Type = "text" }] 
+            };
+        }
+    }
+
+    /// <summary>
+    /// Processes the result of a function execution and converts it to a CallToolResponse
+    /// </summary>
+    private static CallToolResponse ProcessFunctionResult(object? result)
+    {
+        if (result is string resultString)
+            return new CallToolResponse { Content = [new Content() { Text = resultString, Type = "text" }] };
+
+        if (result is string[] resultStringArray)
+            return new CallToolResponse { Content = [.. resultStringArray.Select(s => new Content() { Text = s, Type = "text" })] };
+
+        if (result is null)
+            return new CallToolResponse { Content = [new Content() { Text = "null", Type = "text" }] };
+
+        if (result is JsonElement jsonElement)
+            return new CallToolResponse { Content = [new Content() { Text = jsonElement.GetRawText(), Type = "text" }] };
+
+        // For complex objects, serialize to JSON
+        var serialized = JsonSerializer.Serialize(result);
+        return new CallToolResponse { Content = [new Content() { Text = serialized, Type = "text" }] };
+    }
+    
+    private static string GetParameterType(Type parameterType)
+    {
+        return parameterType switch
+        {
+            Type t when t == typeof(string) => "string",
+            Type t when t == typeof(int) || t == typeof(double) || t == typeof(float) => "number",
+            Type t when t == typeof(bool) => "boolean",
+            Type t when t.IsArray => "array",
+            Type t when t == typeof(DateTime) || t == typeof(DateTimeOffset) => "string",
+            _ => "object"
+        };
+    }
+} 

--- a/src/McpDotNet.Extensions.SemanticKernel/README.md
+++ b/src/McpDotNet.Extensions.SemanticKernel/README.md
@@ -1,0 +1,120 @@
+# McpDotNet.Extensions.SemanticKernel
+
+This package provides integration between Microsoft Semantic Kernel and the MCP (Microsoft Copilot Protocol) server implementation in mcpdotnet.
+
+## Features
+
+- Expose Semantic Kernel plugins as MCP tools
+- Seamlessly integrate AI capabilities from Semantic Kernel with MCP clients
+- Automatic conversion between Semantic Kernel function parameters and MCP tool schemas
+
+## Getting Started
+
+First, install the package:
+
+```bash
+dotnet add package McpDotNet.Extensions.SemanticKernel
+```
+
+Then, in your application:
+
+```csharp
+using McpDotNet;
+using McpDotNet.Server;
+using Microsoft.Extensions.Hosting;
+using Microsoft.SemanticKernel;
+
+// Create a Semantic Kernel instance
+var builder = Kernel.CreateBuilder();
+// Configure your kernel with plugins, AI services, etc.
+builder.Plugins.AddFromType<YourPlugin>();
+var kernel = builder.Build();
+
+// Create an MCP server and integrate with Semantic Kernel
+var hostBuilder = Host.CreateApplicationBuilder();
+hostBuilder.Services
+    .AddMcpServer()
+    .WithStdioServerTransport()
+    .WithSemanticKernel(kernel);
+
+// Run the server
+await hostBuilder.Build().RunAsync();
+```
+
+## Example Usage
+
+### Define a Semantic Kernel Plugin
+
+```csharp
+using Microsoft.SemanticKernel;
+using System.ComponentModel;
+
+public class TimePlugin
+{
+    [KernelFunction, Description("Get the current time")]
+    public string GetCurrentTime()
+    {
+        return DateTime.Now.ToString("HH:mm:ss");
+    }
+
+    [KernelFunction, Description("Get the current date")]
+    public string GetCurrentDate()
+    {
+        return DateTime.Now.ToString("yyyy-MM-dd");
+    }
+}
+```
+
+### Expose the Plugin via MCP
+
+```csharp
+// Register the plugin with Semantic Kernel
+var builder = Kernel.CreateBuilder();
+builder.Plugins.AddFromType<TimePlugin>();
+var kernel = builder.Build();
+
+// Create an MCP server with the Semantic Kernel integration
+var hostBuilder = Host.CreateApplicationBuilder();
+hostBuilder.Services
+    .AddMcpServer()
+    .WithStdioServerTransport()
+    .WithSemanticKernel(kernel);
+
+// Run the server
+await hostBuilder.Build().RunAsync();
+```
+
+Now your Semantic Kernel functions are available as MCP tools that can be called by any MCP client.
+
+## How It Works
+
+The integration:
+
+1. Scans all plugins registered in the Semantic Kernel instance
+2. Converts each function to an MCP tool with appropriate schema
+3. Handles parameter conversion between MCP tool calls and Semantic Kernel functions
+4. Returns function results as MCP tool responses
+
+## Advanced Configuration
+
+You can customize the integration by implementing your own handlers:
+
+```csharp
+// Custom handling for specific tools
+hostBuilder.Services
+    .AddMcpServer()
+    .WithStdioServerTransport()
+    .WithSemanticKernel(kernel)
+    .WithCallToolHandler((request, cancellationToken) => 
+    {
+        // Custom handling for specific tools
+        if (request.Params?.Name == "custom-tool")
+        {
+            // Custom implementation
+            return new CallToolResponse { ... };
+        }
+        
+        // Fall back to default handler
+        return null;
+    });
+``` 

--- a/src/mcpdotnet/mcpdotnet.csproj
+++ b/src/mcpdotnet/mcpdotnet.csproj
@@ -40,6 +40,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.41.0" />
     <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR adds a new extension package McpDotNet.Extensions.SemanticKernel that provides integration between Microsoft Semantic Kernel and mcpdotnet servers. 

The extension provides a clean, fluent API for exposing Semantic Kernel plugins as MCP tools:

- Automatically converts Semantic Kernel function parameters to MCP tool schemas
- Routes MCP tool calls to the appropriate Semantic Kernel functions
- Properly handles parameter conversion and result formatting

The PR also updates the existing sample to demonstrate the new integration approach.