### PR TITLE
Make JsonSerializerOptionsExtensions public

### DIFF
--- a/src/mcpdotnet/Utils/Json/JsonSerializerOptionsExtensions.cs
+++ b/src/mcpdotnet/Utils/Json/JsonSerializerOptionsExtensions.cs
@@ -11,8 +11,11 @@ namespace McpDotNet.Utils.Json;
 /// <summary>
 /// Extensions for configuring System.Text.Json serialization options for MCP.
 /// </summary>
-internal static partial class JsonSerializerOptionsExtensions
+public static partial class JsonSerializerOptionsExtensions
 {
+    /// <summary>
+    /// Gets the default options to use for MCP-related serialization.
+    /// </summary>
     public static JsonSerializerOptions DefaultOptions { get; } = CreateDefaultOptions();
 
     /// <summary>


### PR DESCRIPTION
# Pull Request

## Description of Changes
The `JsonSerializerOptionsExtensions` class is currently marked internal, which means the `AspNetCoreSseServer` sample code won't work elsewhere.
E.g. grabbing `McpEndpointRouteBuilderExtensions` and putting it in a new project and referencing `mcpdotnet` causes a compile error because of the following line (amongst others):
```csharp
var message = await context.Request.ReadFromJsonAsync<IJsonRpcMessage>(JsonSerializerOptionsExtensions.DefaultOptions, context.RequestAborted);
```
Making it public resolves the compile error, and the server works quite nicely.

Apologies in advance if I've missed something obvious. If that's the case, feel free to close out the PR.                

## Related Issue(s)
I did not create an issue for this item.

## Testing Done
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

## Breaking Changes
None