### PR TITLE
added some basic api key framework to the sse example server

### DIFF
--- a/samples/AspNetCoreSseServer/ApiKeyMiddleware.cs
+++ b/samples/AspNetCoreSseServer/ApiKeyMiddleware.cs
@@ -1,0 +1,42 @@
+﻿namespace AspNetCoreSseServer
+{
+    public class ApiKeyMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private const string API_KEY_HEADER_NAME = "X-API-KEY";
+        private readonly string _expectedApiKey;
+
+        public ApiKeyMiddleware(RequestDelegate next, IConfiguration configuration)
+        {
+            _next = next;
+            // Retrieve the expected API key from configuration
+            _expectedApiKey = configuration["AppSettings:apikey"];
+            if (string.IsNullOrWhiteSpace(_expectedApiKey))
+            {
+                throw new InvalidOperationException("apikey is not set in configuration. Please check your appsettings.json.");
+            }
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            // Check if the API key header exists
+            if (!context.Request.Headers.TryGetValue(API_KEY_HEADER_NAME, out var extractedApiKey))
+            {
+                context.Response.StatusCode = 401; // Unauthorized
+                await context.Response.WriteAsync("API Key was not provided.");
+                return;
+            }
+
+            // Validate the API key
+            if (!string.Equals(extractedApiKey, _expectedApiKey))
+            {
+                context.Response.StatusCode = 401; // Unauthorized
+                await context.Response.WriteAsync("Unauthorized client.");
+                return;
+            }
+
+            // Call the next middleware in the pipeline
+            await _next(context);
+        }
+    }
+}

--- a/samples/AspNetCoreSseServer/Program.cs
+++ b/samples/AspNetCoreSseServer/Program.cs
@@ -5,6 +5,9 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddMcpServer().WithTools();
 var app = builder.Build();
 
+// Uncomment to use X-API-KEY middleware
+//app.UseMiddleware<ApiKeyMiddleware>();
+
 app.MapGet("/", () => "Hello World!");
 app.MapMcpSse();
 

--- a/samples/AspNetCoreSseServer/appsettings.json
+++ b/samples/AspNetCoreSseServer/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "AppSettings": {
+    "apikey": "testapikey01234!"
+  }
 }


### PR DESCRIPTION
# Pull Request

## Description of Changes
Added a basic X-API-KEY header check mechanism to protect the sample SSE Server.  It is turned off by default but has a comment about uncommenting to turn it on.  Not a huge contribution but figured it might help other users.

## Related Issue(s)

- Fixes #106

## Testing Done
<!-- Describe the testing you have performed -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
